### PR TITLE
Use empty string fallback instead of .toString method

### DIFF
--- a/src/dataviews/category-dataview/search-model.js
+++ b/src/dataviews/category-dataview/search-model.js
@@ -81,13 +81,13 @@ module.exports = Model.extend({
 
   _parseData: function (categories) {
     var newData = [];
-    _.each(categories, function (d) {
-      if (!d.agg) {
+    _.each(categories, function (data) {
+      if (!data.agg) {
         newData.push({
           selected: false,
-          name: (d.category || d.name).toString(),
-          agg: d.agg,
-          value: d.value
+          name: data.category || data.name || '',
+          agg: data.agg,
+          value: data.value
         });
       }
     }, this);


### PR DESCRIPTION
Related to: https://github.com/CartoDB/support/issues/1368

Prevents getting `Uncaught Error: Cannot read property 'toString' of null` when the API returns `null` names in the response.