### PR TITLE
Popups with just images don't look good on IE and Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb.js",
-  "version": "4.0.0-beta.40",
+  "version": "4.0.0-beta.40-13808",
   "description": "CARTO javascript library",
   "repository": {
     "type": "git",

--- a/src/geo/ui/infowindow-view.js
+++ b/src/geo/ui/infowindow-view.js
@@ -313,6 +313,11 @@ var Infowindow = View.extend({
   },
 
   _loadImageHook: function (imageDimensions, coverDimensions, url) {
+    var cssClipPathNotSupported = util.ie || util.browser.ie || util.browser.edge;
+    if (cssClipPathNotSupported) {
+      return;
+    }
+
     var $hook = this.$('.CDB-hook');
 
     if (!$hook) {


### PR DESCRIPTION
Related to https://github.com/CartoDB/cartodb/issues/13808

[WIP] This is the simplest solution: disable css clip-path when using IE or Edge, as it is not supported (https://caniuse.com/#feat=css-clip-path). 

The result is displayed below (notice the triangle, that was previously hidden):

![image](https://user-images.githubusercontent.com/458196/38822905-28de5b68-41a5-11e8-84db-aa2fc658c76c.png)

