### PR TITLE
Enable stale bot

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,29 @@
+### Context
+*Please explain here below what you were doing when the issue happened*
+
+
+
+### Steps to Reproduce
+*Please break down here below all the needed steps to reproduce the issue*
+
+1.
+2.
+3.
+
+### Current Result
+*Please describe here below the current result you got*
+
+
+
+### Expected result
+*Please describe here below what should be the expected behaviour*
+
+
+### Browser and version
+*What internet browser (Chrome, Firefox, etc) and version was you using and version*
+
+
+
+### Additional info
+*Please add any information of interest here below*
+

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,53 @@
+# Configuration for probot-stale - https://github.com/probot/stale
+
+# Number of days of inactivity before an Issue or Pull Request becomes stale
+daysUntilStale: 365
+
+# Number of days of inactivity before a stale Issue or Pull Request is closed.
+# Set to false to disable. If disabled, issues still need to be closed manually, but will remain marked as stale.
+daysUntilClose: 14
+
+# Issues or Pull Requests with these labels will never be considered stale. Set to `[]` to disable
+# exemptLabels:
+#   - pinned
+#   - security
+#   - "[Status] Maybe Later"
+
+# Set to true to ignore issues in a project (defaults to false)
+exemptProjects: false
+
+# Set to true to ignore issues in a milestone (defaults to false)
+exemptMilestones: false
+
+# Label to use when marking as stale
+staleLabel: stale
+
+# Comment to post when marking as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  recent activity. It will be closed if no further activity occurs. Thank you
+  for your contributions.
+
+# Comment to post when removing the stale label.
+unmarkComment: false
+
+# Comment to post when closing a stale Issue or Pull Request.
+closeComment: false
+
+# Limit the number of actions per hour, from 1-30. Default is 30
+limitPerRun: 10
+
+# Limit to only `issues` or `pulls`
+# only: issues
+
+# Optionally, specify configuration settings that are specific to just 'issues' or 'pulls':
+# pulls:
+#   daysUntilStale: 30
+#   markComment: >
+#     This pull request has been automatically marked as stale because it has not had
+#     recent activity. It will be closed if no further activity occurs. Thank you
+#     for your contributions.
+
+# issues:
+#   exemptLabels:
+#     - confirmed


### PR DESCRIPTION
This PR sets stale bot for CARTO.js.

It adds an issue template as well.