### PR TITLE
Upgrading carto.js to gmaps v3.31

### DIFF
--- a/examples/public/filters/bounding-box-gmaps.html
+++ b/examples/public/filters/bounding-box-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/filters/bounding-box-gmaps.html
+++ b/examples/public/filters/bounding-box-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/change-feature-columns-gmaps.html
+++ b/examples/public/layers/change-feature-columns-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/change-feature-columns-gmaps.html
+++ b/examples/public/layers/change-feature-columns-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/change-order-gmaps.html
+++ b/examples/public/layers/change-order-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/change-order-gmaps.html
+++ b/examples/public/layers/change-order-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/change-source-gmaps.html
+++ b/examples/public/layers/change-source-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/change-source-gmaps.html
+++ b/examples/public/layers/change-source-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/change-style-gmaps.html
+++ b/examples/public/layers/change-style-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/change-style-gmaps.html
+++ b/examples/public/layers/change-style-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/feature-click-gmaps.html
+++ b/examples/public/layers/feature-click-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/feature-click-gmaps.html
+++ b/examples/public/layers/feature-click-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/feature-over-out-gmaps.html
+++ b/examples/public/layers/feature-over-out-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/feature-over-out-gmaps.html
+++ b/examples/public/layers/feature-over-out-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/layer-with-aggregation-gmaps.html
+++ b/examples/public/layers/layer-with-aggregation-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/layer-with-aggregation-gmaps.html
+++ b/examples/public/layers/layer-with-aggregation-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/layer-with-zoom-options-gmaps.html
+++ b/examples/public/layers/layer-with-zoom-options-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/layers/layer-with-zoom-options-gmaps.html
+++ b/examples/public/layers/layer-with-zoom-options-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <style>

--- a/examples/public/layers/multilayer-gmaps.html
+++ b/examples/public/layers/multilayer-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/multilayer-gmaps.html
+++ b/examples/public/layers/multilayer-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/single-layer-gmaps.html
+++ b/examples/public/layers/single-layer-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/layers/single-layer-gmaps.html
+++ b/examples/public/layers/single-layer-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/misc/boilerplate-gmaps.html
+++ b/examples/public/misc/boilerplate-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
   </head>

--- a/examples/public/misc/boilerplate-gmaps.html
+++ b/examples/public/misc/boilerplate-gmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0">
     <meta charset="utf-8">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
   </head>

--- a/examples/public/misc/edit-sql-cartocss-gmaps.html
+++ b/examples/public/misc/edit-sql-cartocss-gmaps.html
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/misc/edit-sql-cartocss-gmaps.html
+++ b/examples/public/misc/edit-sql-cartocss-gmaps.html
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/misc/error-handling-gmaps.html
+++ b/examples/public/misc/error-handling-gmaps.html
@@ -7,7 +7,7 @@
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/misc/error-handling-gmaps.html
+++ b/examples/public/misc/error-handling-gmaps.html
@@ -7,7 +7,7 @@
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/misc/guide-gmaps.html
+++ b/examples/public/misc/guide-gmaps.html
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/misc/guide-gmaps.html
+++ b/examples/public/misc/guide-gmaps.html
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/misc/legends-gmaps.html
+++ b/examples/public/misc/legends-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/misc/legends-gmaps.html
+++ b/examples/public/misc/legends-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/misc/populated-places-gmaps.html
+++ b/examples/public/misc/populated-places-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/misc/populated-places-gmaps.html
+++ b/examples/public/misc/populated-places-gmaps.html
@@ -6,7 +6,7 @@
     <meta charset="utf-8">
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/misc/popups-gmaps.html
+++ b/examples/public/misc/popups-gmaps.html
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.30"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/examples/public/misc/popups-gmaps.html
+++ b/examples/public/misc/popups-gmaps.html
@@ -7,7 +7,7 @@
     <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
     <!-- Include Google Maps -->
-    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.32"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyAORE5iCjgLb4sMcWfmyRJgtP9VwfOrbJM&v=3.31"></script>
     <!-- Include CARTO.js -->
     <script src="../../../dist/public/carto.js"></script>
     <link href="../style.css" rel="stylesheet">

--- a/grunt/tasks/jasmine.js
+++ b/grunt/tasks/jasmine.js
@@ -8,7 +8,7 @@ var defaultOptions = {
     // Load & install the source-map-support lib (get proper stack traces from inlined source-maps)
     'node_modules/source-map-support/browser-source-map-support.js',
     'test/install-source-map-support.js',
-    'http://maps.googleapis.com/maps/api/js?key=AIzaSyA4KzmztukvT7C49NSlzWkz75Xg3J_UyFI&v=3.30',
+    'http://maps.googleapis.com/maps/api/js?key=AIzaSyA4KzmztukvT7C49NSlzWkz75Xg3J_UyFI&v=3.32',
     'node_modules/jasmine-ajax/lib/mock-ajax.js',
     'node_modules/leaflet/dist/leaflet-src.js'
   ]

--- a/grunt/tasks/jasmine.js
+++ b/grunt/tasks/jasmine.js
@@ -8,7 +8,7 @@ var defaultOptions = {
     // Load & install the source-map-support lib (get proper stack traces from inlined source-maps)
     'node_modules/source-map-support/browser-source-map-support.js',
     'test/install-source-map-support.js',
-    'http://maps.googleapis.com/maps/api/js?key=AIzaSyA4KzmztukvT7C49NSlzWkz75Xg3J_UyFI&v=3.32',
+    'http://maps.googleapis.com/maps/api/js?key=AIzaSyA4KzmztukvT7C49NSlzWkz75Xg3J_UyFI&v=3.31',
     'node_modules/jasmine-ajax/lib/mock-ajax.js',
     'node_modules/leaflet/dist/leaflet-src.js'
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carto.js",
-  "version": "4.0.0-1",
+  "version": "4.0.0-1-2067",
   "description": "CARTO javascript library",
   "repository": {
     "type": "git",

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -180,9 +180,10 @@ util.isGoogleMapsLoaded = function () {
     throw new Error('Google Maps is required');
   }
   var version = window.google.maps.version;
-  // Currently it seems that there are no problems with v3.32.12, though it is still experimental
-  if (version < '3.0.0' || version >= '3.33.0') {
-    throw new Error('Google Maps version should be >= 3.0 and < 3.33');
+  // Currently it seems that there are no problems with v3.32.12, though it is still `experimental`
+  // We are limiting upper version to 3.31 (currently 3.31.8b: `release`)
+  if (version < '3.0.0' || version >= '3.32.0') {
+    throw new Error('Google Maps version should be >= 3.0 and < 3.32');
   }
 };
 

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -180,6 +180,7 @@ util.isGoogleMapsLoaded = function () {
     throw new Error('Google Maps is required');
   }
   var version = window.google.maps.version;
+  // Currently it seems that there are no problems with v3.32.12, though it is still experimental
   if (version < '3.0.0' || version >= '3.33.0') {
     throw new Error('Google Maps version should be >= 3.0 and < 3.33');
   }

--- a/src/core/util.js
+++ b/src/core/util.js
@@ -180,8 +180,8 @@ util.isGoogleMapsLoaded = function () {
     throw new Error('Google Maps is required');
   }
   var version = window.google.maps.version;
-  if (version < '3.0.0' || version >= '3.31.0') {
-    throw new Error('Google Maps version should be >= 3.0 and < 3.31');
+  if (version < '3.0.0' || version >= '3.33.0') {
+    throw new Error('Google Maps version should be >= 3.0 and < 3.33');
   }
 };
 

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -325,7 +325,7 @@ describe('api/v4/client', function () {
       window.google.maps = { version: '2.4' };
       expect(function () {
         client.getGoogleMapsMapType();
-      }).toThrowError('Google Maps version should be >= 3.0 and < 3.31');
+      }).toThrowError('Google Maps version should be >= 3.0 and < 3.33');
 
       // Restore window.google
       window.google = google;

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -325,7 +325,7 @@ describe('api/v4/client', function () {
       window.google.maps = { version: '2.4' };
       expect(function () {
         client.getGoogleMapsMapType();
-      }).toThrowError('Google Maps version should be >= 3.0 and < 3.33');
+      }).toThrowError('Google Maps version should be >= 3.0 and < 3.32');
 
       // Restore window.google
       window.google = google;

--- a/test/spec/core/util.spec.js
+++ b/test/spec/core/util.spec.js
@@ -67,7 +67,7 @@ describe('core/util', function () {
       window.google = existingGMaps;
     });
 
-    it('gmaps is required as global and it must be between 3.0 and 3.31', function () {
+    it('gmaps is required as global and it must be between 3.0 and 3.32', function () {
       var checkGoogle = function () {
         util.isGoogleMapsLoaded();
       };
@@ -77,18 +77,19 @@ describe('core/util', function () {
       window.google = { something: 'something' };
       expect(checkGoogle).toThrowError('Google Maps is required');
 
+      var INVALID_VERSION_MESSAGE = 'Google Maps version should be >= 3.0 and < 3.33';
       window.google.maps = {
         version: '2.9.9'
       };
-      expect(checkGoogle).toThrowError('Google Maps version should be >= 3.0 and < 3.31');
+      expect(checkGoogle).toThrowError(INVALID_VERSION_MESSAGE);
 
       window.google.maps = {
-        version: '3.31.0'
+        version: '3.33.0'
       };
-      expect(checkGoogle).toThrowError('Google Maps version should be >= 3.0 and < 3.31');
+      expect(checkGoogle).toThrowError(INVALID_VERSION_MESSAGE);
 
       window.google.maps = {
-        version: '3.30.0'
+        version: '3.32.0'
       };
       expect(checkGoogle).not.toThrow();
     });

--- a/test/spec/core/util.spec.js
+++ b/test/spec/core/util.spec.js
@@ -67,7 +67,7 @@ describe('core/util', function () {
       window.google = existingGMaps;
     });
 
-    it('gmaps is required as global and it must be between 3.0 and 3.32', function () {
+    it('gmaps is required as global and it must be between 3.0 and 3.31', function () {
       var checkGoogle = function () {
         util.isGoogleMapsLoaded();
       };
@@ -77,19 +77,19 @@ describe('core/util', function () {
       window.google = { something: 'something' };
       expect(checkGoogle).toThrowError('Google Maps is required');
 
-      var INVALID_VERSION_MESSAGE = 'Google Maps version should be >= 3.0 and < 3.33';
+      var INVALID_VERSION_MESSAGE = 'Google Maps version should be >= 3.0 and < 3.32';
       window.google.maps = {
         version: '2.9.9'
       };
       expect(checkGoogle).toThrowError(INVALID_VERSION_MESSAGE);
 
       window.google.maps = {
-        version: '3.33.0'
+        version: '3.32.0'
       };
       expect(checkGoogle).toThrowError(INVALID_VERSION_MESSAGE);
 
       window.google.maps = {
-        version: '3.32.0'
+        version: '3.31.0'
       };
       expect(checkGoogle).not.toThrow();
     });

--- a/test/spec/geo/geometry-views/shared-tests-for-polygon-views.js
+++ b/test/spec/geo/geometry-views/shared-tests-for-polygon-views.js
@@ -7,7 +7,7 @@ module.exports = function (MapView, PathView) {
   SharedTestsForPathViews.call(this, Polygon, MapView, PathView);
 
   describe('expandable polygons', function () {
-    beforeEach(function () {
+    beforeEach(function (done) {
       this.mapView = createMapView(MapView);
       this.mapView.render();
 
@@ -25,7 +25,12 @@ module.exports = function (MapView, PathView) {
         mapView: this.mapView
       });
 
-      this.geometryView.render();
+      // Listen for the map to be ready
+      this.mapView.onReady(function () {
+        this.geometryView.render();
+
+        done();
+      }.bind(this));
     });
 
     it('should render markers for each vertex, the path, and middle points', function () {

--- a/test/spec/geo/geometry-views/shared-tests-for-polyline-views.js
+++ b/test/spec/geo/geometry-views/shared-tests-for-polyline-views.js
@@ -7,7 +7,7 @@ module.exports = function (MapView, PathView) {
   SharedTestsForPathViews.call(this, Polyline, MapView, PathView);
 
   describe('expandable polylines', function () {
-    beforeEach(function () {
+    beforeEach(function (done) {
       this.mapView = createMapView(MapView);
       this.mapView.render();
 
@@ -25,7 +25,12 @@ module.exports = function (MapView, PathView) {
         mapView: this.mapView
       });
 
-      this.geometryView.render();
+      // Listen for the map to be ready
+      this.mapView.onReady(function () {
+        this.geometryView.render();
+
+        done();
+      }.bind(this));
     });
 
     it('should render markers for each vertex, the path, and middle points', function () {


### PR DESCRIPTION
Related to https://github.com/CartoDB/carto.js/issues/2067

**Context**
- Current tests and examples are now working fine with v3.32 (experimental)
- We have decided though to upgrade to v3.31 (stable) and wait for v3.32 to stabilize

---
**Tasks**
- [x] Dev
- [x] Frontend CR
- [ ] Public release
- [ ] Dev. docs update

**Acceptance**
- [ ] Dev center (https://carto.com/developers/) reflects this upgrade
- [ ] npm version is XX.XXX
