### PR TITLE
Better popups with just images on IE and Edge

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carto.js",
-  "version": "4.0.1-0-13808",
+  "version": "4.0.1-13808",
   "description": "CARTO javascript library",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "carto.js",
-  "version": "4.0.1-0",
+  "version": "4.0.1-0-13808",
   "description": "CARTO javascript library",
   "repository": {
     "type": "git",

--- a/src/geo/ui/infowindow-view.js
+++ b/src/geo/ui/infowindow-view.js
@@ -313,8 +313,12 @@ var Infowindow = View.extend({
   },
 
   _loadImageHook: function (imageDimensions, coverDimensions, url) {
-    var $hook = this.$('.CDB-hook');
+    var cssClipPathNotSupported = util.ie || util.browser.ie || util.browser.edge;
+    if (cssClipPathNotSupported) {
+      return;
+    }
 
+    var $hook = this.$('.CDB-hook');
     if (!$hook) {
       return;
     }

--- a/src/geo/ui/infowindow-view.js
+++ b/src/geo/ui/infowindow-view.js
@@ -312,14 +312,19 @@ var Infowindow = View.extend({
     return false;
   },
 
+  _imageOnHookNotSupported: function () {
+    var noCssClipPath = util.ie || util.browser.ie || util.browser.edge;
+    return noCssClipPath;
+  },
+
   _loadImageHook: function (imageDimensions, coverDimensions, url) {
-    var cssClipPathNotSupported = util.ie || util.browser.ie || util.browser.edge;
-    if (cssClipPathNotSupported) {
+    var $hook = this.$('.CDB-hook');
+    if (!$hook) {
       return;
     }
 
-    var $hook = this.$('.CDB-hook');
-    if (!$hook) {
+    if (this._imageOnHookNotSupported()) {
+      $hook.hide();
       return;
     }
 


### PR DESCRIPTION
Related to CartoDB/cartodb#13808

Popups with just images don't look good on IE and Edge, because they don't support the CSS clip-path property, used on the hook.

This PR provides a fallback, removing the clipped image and the hook itself.

The result looks like this (on IE11):

![image](https://user-images.githubusercontent.com/458196/39198260-e7caa10c-47e6-11e8-8f95-d7dab299d1b7.png)
