### PR TITLE
Fix remove layers

### DIFF
--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -163,7 +163,13 @@ Client.prototype.removeLayer = function (layer) {
  * @api
  */
 Client.prototype.removeLayers = function (layers) {
-  layers.forEach(this._removeLayer, this);
+  var clone = layers.slice(0);
+  var length = layers.length;
+  var i = 0;
+  for (i = 0; i < length; i++) {
+    this._removeLayer(clone[i]);
+  }
+
   return this._reload();
 };
 

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -163,12 +163,8 @@ Client.prototype.removeLayer = function (layer) {
  * @api
  */
 Client.prototype.removeLayers = function (layers) {
-  var clone = layers.slice(0);
-  var length = layers.length;
-  var i = 0;
-  for (i = 0; i < length; i++) {
-    this._removeLayer(clone[i]);
-  }
+  var layersToRemove = layers.slice(0);
+  layersToRemove.forEach(this._removeLayer, this);
 
   return this._reload();
 };

--- a/src/api/v4/layers.js
+++ b/src/api/v4/layers.js
@@ -10,7 +10,7 @@ Layers.prototype.add = function (layer) {
 };
 
 Layers.prototype.remove = function (layer) {
-  return this._layers.splice(this._layers.indexOf(layer));
+  return this._layers.splice(this._layers.indexOf(layer), 1);
 };
 
 Layers.prototype.size = function () {

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -193,6 +193,23 @@ describe('api/v4/client', function () {
     });
   });
 
+  describe('.removeLayers', function () {
+    it('must remove all layers', function () {
+      var source = new carto.source.Dataset('ne_10m_populated_places_simple');
+      var style = new carto.style.CartoCSS('#layer {  marker-fill: red; }');
+      var layerA = new carto.layer.Layer(source, style, {});
+      var layerB = new carto.layer.Layer(source, style, {});
+      var layerC = new carto.layer.Layer(source, style, {});
+      client.addLayers([layerA, layerB, layerC]);
+
+      expect(client.getLayers().length).toEqual(3);
+
+      client.removeLayers(client.getLayers());
+
+      expect(client.getLayers().length).toEqual(0);
+    });
+  });
+
   describe('.moveLayer', function () {
     it('should throw a descriptive error when the parameter is invalid', function () {
       var source = new carto.source.Dataset('ne_10m_populated_places_simple');

--- a/test/spec/api/v4/layers.spec.js
+++ b/test/spec/api/v4/layers.spec.js
@@ -1,0 +1,41 @@
+var Layers = require('../../../../src/api/v4/layers');
+
+describe('api/v4/layers', function () {
+  var layers;
+
+  function createFakeLayer (id) {
+    return {
+      getId: function () {
+        return id;
+      }
+    };
+  }
+
+  function seedLayers (layers) {
+    var layerA = createFakeLayer('A');
+    var layerB = createFakeLayer('B');
+    var layerC = createFakeLayer('C');
+
+    layers.add(layerA);
+    layers.add(layerB);
+    layers.add(layerC);
+
+    return [layerA, layerB, layerC];
+  }
+
+  beforeEach(function () {
+    layers = new Layers();
+  });
+
+  describe('.remove', function () {
+    it('should remove the layer from the collection', function () {
+      var createdLayers = seedLayers(layers);
+
+      layers.remove(createdLayers[1]);
+
+      expect(layers.size()).toBe(2);
+      expect(layers.indexOf(createdLayers[0])).toBe(0);
+      expect(layers.indexOf(createdLayers[2])).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
This PR fixes `removeLayers`.

We were removing elements from the same array that we were traversing. The side effect of that is that the internal array was not completely emptied so next time the user instantiate the map, it has layers that were supposed to be removed.

This PR adds also missing tests. Neither `client.removeLayers` nor `layers.remove` had any.