### PR TITLE
Rename package to internal-carto.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@carto/carto.js",
+  "name": "internal-carto.js",
   "version": "4.0.6",
   "description": "CARTO javascript library",
   "repository": {


### PR DESCRIPTION
We need to rename the package to be able to have both this version and the public one on builder.

Sorry for the lengthy Code Review