### PR TITLE
Small typo fixes for dev center docs

### DIFF
--- a/docs/guides/01-quickstart.md
+++ b/docs/guides/01-quickstart.md
@@ -50,7 +50,7 @@ Create an HTML file using your preferred text editor and paste the following cod
     <!-- Include CARTO.js -->
     <script src="https://cartodb-libs.global.ssl.fastly.net/carto.js/%VERSION%/carto.min.js"></script>
     <!-- Fonts -->
-    <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700' rel='stylesheet' type='text/css'>
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel='stylesheet' type='text/css'>
     <style>
       * { margin:0; padding:0; }
       html { box-sizing:border-box; height:100%; }

--- a/docs/guides/01-quickstart.md
+++ b/docs/guides/01-quickstart.md
@@ -50,7 +50,7 @@ Create an HTML file using your preferred text editor and paste the following cod
     <!-- Include CARTO.js -->
     <script src="https://cartodb-libs.global.ssl.fastly.net/carto.js/%VERSION%/carto.min.js"></script>
     <!-- Fonts -->
-    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel='stylesheet' type='text/css'>
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet" type="text/css">
     <style>
       * { margin:0; padding:0; }
       html { box-sizing:border-box; height:100%; }

--- a/docs/support/03-error-messages.md
+++ b/docs/support/03-error-messages.md
@@ -66,7 +66,6 @@ If you find a validation error on Chrome JavaScript Console, Firefox Web Console
     <tr>
       <th class="error"><h5 class="title is-small is-regular">Error Code</h5></th>
       <th class="message"><h5 class="title is-small is-regular">Message</h5></th>
-      <th class="description"><h5 class="title is-small is-regular">Description</h5></th>
     </tr>
   </thead>
   <tbody>


### PR DESCRIPTION
Related issues: 
- Dataview error table dangling column https://github.com/CartoDB/developers/issues/297
- carto.js quickstart app skeleton quote consistency https://github.com/CartoDB/developers/issues/295