### PR TITLE
Fix iOS examples

### DIFF
--- a/examples/public/filters/bounding-box-gmaps.html
+++ b/examples/public/filters/bounding-box-gmaps.html
@@ -36,7 +36,7 @@
   </aside>
 
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 30, lng: 0 },
       zoom: 3,
       zoomControl: true,

--- a/examples/public/layers/change-feature-columns-gmaps.html
+++ b/examples/public/layers/change-feature-columns-gmaps.html
@@ -49,7 +49,7 @@
   </aside>
 
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 30, lng: 0 },
       zoom: 3,
       fullscreenControl: false,

--- a/examples/public/layers/change-order-gmaps.html
+++ b/examples/public/layers/change-order-gmaps.html
@@ -44,7 +44,7 @@
     </div>
   </aside>
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 30, lng: 0 },
       zoom: 3,
       fullscreenControl: false,

--- a/examples/public/layers/change-source-gmaps.html
+++ b/examples/public/layers/change-source-gmaps.html
@@ -51,7 +51,7 @@
   </aside>
 
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 30, lng: 0 },
       zoom: 3,
       fullscreenControl: false,

--- a/examples/public/layers/change-style-gmaps.html
+++ b/examples/public/layers/change-style-gmaps.html
@@ -49,7 +49,7 @@
     </div>
   </aside>
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 30, lng: 0 },
       zoom: 3,
       fullscreenControl: false,

--- a/examples/public/layers/feature-click-gmaps.html
+++ b/examples/public/layers/feature-click-gmaps.html
@@ -39,7 +39,7 @@
   </aside>
 
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 30, lng: 0 },
       zoom: 3,
       fullscreenControl: false,

--- a/examples/public/layers/feature-over-out-gmaps.html
+++ b/examples/public/layers/feature-over-out-gmaps.html
@@ -39,7 +39,7 @@
   </aside>
 
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 30, lng: 0 },
       zoom: 3,
       fullscreenControl: false,

--- a/examples/public/layers/layer-with-aggregation-gmaps.html
+++ b/examples/public/layers/layer-with-aggregation-gmaps.html
@@ -30,7 +30,7 @@
   </aside>
 
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 30, lng: 0 },
       zoom: 3,
       fullscreenControl: false,

--- a/examples/public/layers/layer-with-zoom-options-gmaps.html
+++ b/examples/public/layers/layer-with-zoom-options-gmaps.html
@@ -26,7 +26,7 @@
 <body>
   <div id="map"></div>
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 30, lng: 0 },
       zoom: 3
     });

--- a/examples/public/layers/multilayer-gmaps.html
+++ b/examples/public/layers/multilayer-gmaps.html
@@ -29,7 +29,7 @@
   </aside>
 
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 40, lng: 0 },
       zoom: 5,
       fullscreenControl: false,

--- a/examples/public/layers/single-layer-gmaps.html
+++ b/examples/public/layers/single-layer-gmaps.html
@@ -29,7 +29,7 @@
   </aside>
 
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 30, lng: 0 },
       zoom: 3,
       fullscreenControl: false,

--- a/examples/public/misc/edit-sql-cartocss-gmaps.html
+++ b/examples/public/misc/edit-sql-cartocss-gmaps.html
@@ -53,7 +53,7 @@
   </aside>
 
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 30, lng: 0 },
       zoom: 3,
       fullscreenControl: false,

--- a/examples/public/misc/error-handling-gmaps.html
+++ b/examples/public/misc/error-handling-gmaps.html
@@ -54,7 +54,7 @@
 
   <script>
     // Setting up a Google Maps Map
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 50, lng: 15 },
       zoom: 4,
       fullscreenControl: false,

--- a/examples/public/misc/guide-gmaps.html
+++ b/examples/public/misc/guide-gmaps.html
@@ -52,7 +52,7 @@
   <script>
     // 1. Setting up a Google Maps Map
     // 1.1 Creating the Google Maps Map
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 50, lng: 15 },
       zoom: 4,
       fullscreenControl: false,

--- a/examples/public/misc/legends-gmaps.html
+++ b/examples/public/misc/legends-gmaps.html
@@ -70,7 +70,7 @@
   </aside>
 
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 30, lng: 0 },
       zoom: 3,
       fullscreenControl: false,

--- a/examples/public/misc/populated-places-gmaps.html
+++ b/examples/public/misc/populated-places-gmaps.html
@@ -47,7 +47,7 @@
   </aside>
 
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 30, lng: 0 },
       zoom: 3,
       fullscreenControl: false,

--- a/examples/public/misc/popups-gmaps.html
+++ b/examples/public/misc/popups-gmaps.html
@@ -49,7 +49,7 @@
   </aside>
 
   <script>
-    const map = new google.maps.Map(document.getElementById('map'), {
+    var map = new google.maps.Map(document.getElementById('map'), {
       center: { lat: 30, lng: 0 },
       zoom: 3,
       fullscreenControl: false,


### PR DESCRIPTION
Fixes https://github.com/CartoDB/carto.js/issues/1995

This PR substitutes all `const map` with `var map` in Google Maps examples.
This is a bug in Safari. You can't have an element with an id and a const variable with the same name.