### PR TITLE
Fix margins on legends

### DIFF
--- a/src/geo/ui/legends/base/legend-view-base.js
+++ b/src/geo/ui/legends/base/legend-view-base.js
@@ -6,7 +6,7 @@ var ImageLoaderView = require('./img-loader-view');
 
 var LegendViewBase = Backbone.View.extend({
 
-  className: 'CDB-Legend-item',
+  className: 'CDB-Legend-item u-tSpace-xl u-clearfix',
 
   initialize: function (opts) {
     this._placeholderTemplate = opts.placeholderTemplate;

--- a/src/geo/ui/legends/base/legend-view-base.js
+++ b/src/geo/ui/legends/base/legend-view-base.js
@@ -6,7 +6,7 @@ var ImageLoaderView = require('./img-loader-view');
 
 var LegendViewBase = Backbone.View.extend({
 
-  className: 'CDB-Legend-item u-tSpace-xl u-clearfix',
+  className: 'CDB-Legend-item u-tSpace-xl',
 
   initialize: function (opts) {
     this._placeholderTemplate = opts.placeholderTemplate;

--- a/src/geo/ui/legends/bubble/legend-view.js
+++ b/src/geo/ui/legends/bubble/legend-view.js
@@ -5,6 +5,8 @@ var formatter = require('../../../../util/formatter');
 
 var BubbleLegendView = LegendViewBase.extend({
 
+  className: 'CDB-Legend-item u-tSpace-xl u-clearfix',
+
   _getCompiledTemplate: function () {
     return template({
       hasCustomLabels: this._hasCustomLabels(),

--- a/src/geo/ui/legends/layer-legends-template.tpl
+++ b/src/geo/ui/legends/layer-legends-template.tpl
@@ -13,5 +13,5 @@
 </h2>
 
 <% if (showLegends) { %>
-<div class="Legends js-legends u-tSpace-xl"></div>
+<div class="Legends js-legends"></div>
 <% } %>

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -322,7 +322,7 @@ $maxLegendContainerHeight: 300px;
   right: 0;
   width: 100%;
   height: 100px;
-  margin: 16px 0 10px 0;
+  margin: 16px 0 10px;
 }
 
 .Bubble-circle {

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -318,11 +318,11 @@ $maxLegendContainerHeight: 300px;
 
 .Bubble-container {
   position: relative;
-  top: 7px;
+  top: 0;
   right: 0;
   width: 100%;
   height: 100px;
-  margin: 10px 0;
+  margin: 16px 0 10px 0;
 }
 
 .Bubble-circle {

--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -230,7 +230,7 @@ $maxLegendContainerHeight: 300px;
 .CDB-LayerLegends {
   margin-top: 0;
 
-  + .CDB-LayerLegends {
+  &:not(:empty) + &:not(:empty) {
     margin-top: 12px;
   }
 }


### PR DESCRIPTION
This PR fixes margins and spacing on legends, specially on Bubble legend.

The problem was that the legend was taking more space than what it has assigned due to absolute positioning. So the margins were collapsed, appearing misaligned.

### Acceptance
See https://github.com/CartoDB/support/issues/1566

Related to https://github.com/CartoDB/support/issues/1566
