### PR TITLE
Fix interactivity when only 'cartodb_id' is selected

### DIFF
--- a/src/geo/map/cartodb-layer.js
+++ b/src/geo/map/cartodb-layer.js
@@ -74,8 +74,7 @@ var CartoDBLayer = LayerModelBase.extend({
   },
 
   isInteractive: function () {
-    // By default it has one field (cartodb_id)
-    return this.getInteractiveColumnNames().length > 1;
+    return this._hasInfowindowFields() || this._hasTooltipFields();
   },
 
   _hasInfowindowFields: function () {

--- a/test/spec/api/v4/layer/layer.spec.js
+++ b/test/spec/api/v4/layer/layer.spec.js
@@ -625,6 +625,30 @@ describe('api/v4/layer', function () {
     });
   });
 
+  describe('.isInteractive', function () {
+    it('returns true if layer has featureClickColumns', function () {
+      const layer = new carto.layer.Layer(source, style, {
+        featureClickColumns: ['cartodb_id']
+      });
+
+      expect(layer.isInteractive()).toBe(true);
+    });
+
+    it('returns true if layer has featureOverColumns', function () {
+      const layer = new carto.layer.Layer(source, style, {
+        featureOverColumns: ['cartodb_id']
+      });
+
+      expect(layer.isInteractive()).toBe(true);
+    });
+
+    it('returns false if layer doesn\'t have getFeatureClickColumns or getFeatureHoverColumns', function () {
+      const layer = new carto.layer.Layer(source, style);
+
+      expect(layer.isInteractive()).toBe(false);
+    });
+  });
+
   xit('should update "internalmodel.cartocss" when the style is updated', function (done) {
     var client = new carto.Client({
       apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',

--- a/test/spec/geo/map/cartodb-layer.spec.js
+++ b/test/spec/geo/map/cartodb-layer.spec.js
@@ -145,6 +145,33 @@ describe('geo/map/cartodb-layer', function () {
     });
   });
 
+  describe('.isInteractive', function () {
+    var layer, infowindowSpy, tooltipSpy;
+
+    beforeEach(function () {
+      layer = new CartoDBLayer({}, { engine: engineMock });
+
+      infowindowSpy = spyOn(layer, '_hasInfowindowFields');
+      tooltipSpy = spyOn(layer, '_hasTooltipFields');
+    });
+
+    it('returns true if there are selected fields', function () {
+      infowindowSpy.and.returnValue(true);
+      tooltipSpy.and.returnValue(false);
+      expect(layer.isInteractive()).toBe(true);
+
+      infowindowSpy.and.returnValue(false);
+      tooltipSpy.and.returnValue(true);
+      expect(layer.isInteractive()).toBe(true);
+    });
+
+    it('returns true if there are selected fields', function () {
+      infowindowSpy.and.returnValue(false);
+      tooltipSpy.and.returnValue(false);
+      expect(layer.isInteractive()).toBe(false);
+    });
+  });
+
   describe('.getInteractiveColumnNames', function () {
     it("should return 'cartodb_id' and the names of the fields for infowindows and tooltips with no duplicates", function () {
       this.layer = new CartoDBLayer({


### PR DESCRIPTION
Related to: https://github.com/CartoDB/carto.js/issues/2089

### Description

This PR changes how we check if a layer is interactive or not.

The problem is that we were checking `this.getInteractiveColumnNames().length > 1` because we always add `cartodb_id` by default, so when adding it manually the check was false.