### PR TITLE
Fix removeDataview

### DIFF
--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -295,7 +295,9 @@ Client.prototype.addDataviews = function (dataviews) {
 Client.prototype.removeDataview = function (dataview) {
   var dataviewIndex = this._dataviews.indexOf(dataview);
 
-  if (dataviewIndex === -1) return;
+  if (dataviewIndex === -1) {
+    return Promise.resolve();
+  }
 
   this._dataviews.splice(dataviewIndex, 1);
   this._engine.removeDataview(dataview.$getInternalModel());

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -21,7 +21,7 @@ function getValidationError (code) {
  *
  * To create a new client you need a CARTO account, where you will be able to get
  * your API key and username.
- * 
+ *
  * If you want to learn more about authorization and authentication, please read the authorization fundamentals section of our Developer Center.
  *
  * @param {object} settings
@@ -34,7 +34,7 @@ function getValidationError (code) {
  *   apiKey: 'YOUR_API_KEY_HERE',
  *   username: 'YOUR_USERNAME_HERE'
  * });
- * 
+ *
  * var client = new carto.Client({
  *   apiKey: 'YOUR_API_KEY_HERE',
  *   username: 'YOUR_USERNAME_HERE',
@@ -295,6 +295,7 @@ Client.prototype.addDataviews = function (dataviews) {
 Client.prototype.removeDataview = function (dataview) {
   this._dataviews.splice(this._dataviews.indexOf(dataview));
   this._engine.removeDataview(dataview.$getInternalModel());
+  dataview.disable();
   return this._reload();
 };
 

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -293,7 +293,11 @@ Client.prototype.addDataviews = function (dataviews) {
  * @api
  */
 Client.prototype.removeDataview = function (dataview) {
-  this._dataviews.splice(this._dataviews.indexOf(dataview));
+  var dataviewIndex = this._dataviews.indexOf(dataview);
+
+  if (dataviewIndex === -1) return;
+
+  this._dataviews.splice(dataviewIndex, 1);
   this._engine.removeDataview(dataview.$getInternalModel());
   dataview.disable();
   return this._reload();

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -216,6 +216,45 @@ describe('api/v4/client', function () {
     });
   });
 
+  describe('.removeDataview', function () {
+    var categoryDataview;
+
+    beforeEach(function () {
+      var source = new carto.source.Dataset('ne_10m_populated_places_simple');
+      categoryDataview = new carto.dataview.Category(source, 'adm0name', {
+        limit: 10,
+        operation: carto.operation.SUM,
+        operationColumn: 'pop_max'
+      });
+
+      client.addDataview(categoryDataview);
+
+      spyOn(client._engine, 'removeDataview');
+      spyOn(categoryDataview, 'disable');
+      spyOn(client, '_reload');
+    });
+
+    it('removes the dataview', function () {
+      expect(client._dataviews.length).toBe(1);
+
+      client.removeDataview(categoryDataview);
+
+      expect(client._dataviews.length).toBe(0);
+    });
+
+    it('disables the dataview', function () {
+      client.removeDataview(categoryDataview);
+
+      expect(client._engine.removeDataview).toHaveBeenCalled();
+    });
+
+    it('triggers a reload cycle', function () {
+      client.removeDataview(categoryDataview);
+
+      expect(client._reload).toHaveBeenCalled();
+    });
+  });
+
   describe('.moveLayer', function () {
     it('should throw a descriptive error when the parameter is invalid', function () {
       var source = new carto.source.Dataset('ne_10m_populated_places_simple');

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -217,7 +217,7 @@ describe('api/v4/client', function () {
   });
 
   describe('.removeDataview', function () {
-    var categoryDataview;
+    var categoryDataview, populationDataview;
 
     beforeEach(function () {
       var source = new carto.source.Dataset('ne_10m_populated_places_simple');
@@ -227,7 +227,14 @@ describe('api/v4/client', function () {
         operationColumn: 'pop_max'
       });
 
+      populationDataview = new carto.dataview.Category(source, 'adm1name', {
+        limit: 10,
+        operation: carto.operation.SUM,
+        operationColumn: 'pop_max'
+      });
+
       client.addDataview(categoryDataview);
+      client.addDataview(populationDataview);
 
       spyOn(client._engine, 'removeDataview');
       spyOn(categoryDataview, 'disable');
@@ -235,11 +242,11 @@ describe('api/v4/client', function () {
     });
 
     it('removes the dataview', function () {
-      expect(client._dataviews.length).toBe(1);
+      expect(client._dataviews.length).toBe(2);
 
       client.removeDataview(categoryDataview);
 
-      expect(client._dataviews.length).toBe(0);
+      expect(client._dataviews.length).toBe(1);
     });
 
     it('disables the dataview', function () {


### PR DESCRIPTION
Related to: https://github.com/CartoDB/carto.js/issues/2119

### Description
This PR calls `dataview.disable()` in `removeDataview`.

### Acceptance
- Use the example provided in the issue
- Open the map and check that moving the map calls the api
- Click in the _Remove widget_ button
- Check that moving the map doesn't call the api