### PR TITLE
Add options to getLeafletLayer

### DIFF
--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -21,7 +21,7 @@ function getValidationError (code) {
  *
  * To create a new client you need a CARTO account, where you will be able to get
  * your API key and username.
- * 
+ *
  * If you want to learn more about authorization and authentication, please read the authorization fundamentals section of our Developer Center.
  *
  * @param {object} settings
@@ -34,7 +34,7 @@ function getValidationError (code) {
  *   apiKey: 'YOUR_API_KEY_HERE',
  *   username: 'YOUR_USERNAME_HERE'
  * });
- * 
+ *
  * var client = new carto.Client({
  *   apiKey: 'YOUR_API_KEY_HERE',
  *   username: 'YOUR_USERNAME_HERE',
@@ -324,16 +324,18 @@ Client.prototype.getDataviews = function () {
  * // Add the leafletLayer to a leafletMap
  * client.getLeafletLayer().addTo(map);
  *
+ * @param {object} options - {@link https://leafletjs.com/reference-1.3.0.html#tilelayer-minzoom|L.TileLayer} options.
+ *
  * @returns A {@link http://leafletjs.com/reference-1.3.1.html#tilelayer|L.TileLayer} layer that groups all the layers.
  *
  * @api
  */
-Client.prototype.getLeafletLayer = function () {
+Client.prototype.getLeafletLayer = function (options) {
   // Check if Leaflet is loaded
   utils.isLeafletLoaded();
   if (!this._leafletLayer) {
     var LeafletLayer = require('./native/leaflet-layer');
-    this._leafletLayer = new LeafletLayer(this._layers, this._engine);
+    this._leafletLayer = new LeafletLayer(this._layers, this._engine, options);
   }
   return this._leafletLayer;
 };

--- a/src/api/v4/native/leaflet-layer.js
+++ b/src/api/v4/native/leaflet-layer.js
@@ -25,7 +25,9 @@ var LeafletLayer = L.TileLayer.extend({
     attribution: constants.ATTRIBUTION
   },
 
-  initialize: function (layers, engine) {
+  initialize: function (layers, engine, options) {
+    _.extend(this.options, options);
+
     this._layers = layers;
     this._engine = engine;
     this._internalView = null;

--- a/test/spec/api/v4/native/leaflet-layer.spec.js
+++ b/test/spec/api/v4/native/leaflet-layer.spec.js
@@ -17,14 +17,23 @@ describe('src/api/v4/native/leaflet-layer', function () {
       username: 'cartojs-test'
     });
     map = L.map('map').setView([42.431234, -8.643616], 5);
-    leafletLayer = client.getLeafletLayer();
   });
 
   afterEach(function () {
     document.getElementById('map').remove();
   });
 
+  it('allows custom options', function () {
+    leafletLayer = client.getLeafletLayer({ maxZoom: 10 });
+
+    expect(leafletLayer.options.maxZoom).toBe(10);
+  });
+
   describe('addTo', function () {
+    beforeEach(function () {
+      leafletLayer = client.getLeafletLayer();
+    });
+
     it('should add a leaflet layer to the map', function () {
       expect(countLeafletLayers(map)).toEqual(0);
 
@@ -35,6 +44,10 @@ describe('src/api/v4/native/leaflet-layer', function () {
   });
 
   describe('removeFrom', function () {
+    beforeEach(function () {
+      leafletLayer = client.getLeafletLayer();
+    });
+
     it('should remove the leaflet layer from the map', function () {
       expect(countLeafletLayers(map)).toEqual(0);
 
@@ -55,6 +68,7 @@ describe('src/api/v4/native/leaflet-layer', function () {
     beforeEach(function () {
       spy = jasmine.createSpy('spy');
 
+      leafletLayer = client.getLeafletLayer();
       leafletLayer.addTo(map);
 
       var source = new carto.source.SQL('foo');


### PR DESCRIPTION
Related to: https://github.com/CartoDB/carto.js/issues/2125

### Description
This PR allows passing options to `getLeafletLayer` to override our default options.

### Acceptance
Open the `single-layer-leaflet.html` example and use this code:

```html
<script>
  const map = L.map('map').setView([30, 0], 1);
  map.scrollWheelZoom.disable();

  L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}.png', {
    maxZoom: 18,
    noWrap: true
  }).addTo(map);

  const client = new carto.Client({
    apiKey: 'default_public',
    username: 'cartojs-test'
  });

  const source = new carto.source.Dataset(`
    ne_10m_populated_places_simple
  `);
  const style = new carto.style.CartoCSS(`
    #layer {
      marker-width: 7;
      marker-fill: #EE4D5A;
      marker-line-color: #FFFFFF;
    }
  `);
  const layer = new carto.layer.Layer(source, style);

  client.addLayer(layer);
  client.getLeafletLayer({
    noWrap: true,
    bounds: [
      [-90, -180],
      [90, 180]
    ]
  }).addTo(map);
</script>
```

Before:
![screen shot 2018-06-29 at 09 07 24](https://user-images.githubusercontent.com/905225/42078201-e3281d96-7b7b-11e8-96d5-9efecf0cb925.png)

After:

![screen shot 2018-06-29 at 09 06 56](https://user-images.githubusercontent.com/905225/42078194-df751c08-7b7b-11e8-9b1f-69012430c46e.png)
