### PR TITLE
Add century and millenium to date aggregation

### DIFF
--- a/src/dataviews/helpers/histogram-helper.js
+++ b/src/dataviews/helpers/histogram-helper.js
@@ -9,7 +9,9 @@ var AGGREGATION_DATA = {
   month: { unit: 'month', factor: 1 },
   quarter: { unit: 'month', factor: 3 },
   year: { unit: 'month', factor: 12 },
-  decade: { unit: 'month', factor: 120 }
+  decade: { unit: 'month', factor: 120 },
+  century: { unit: 'month', factor: 1200 },
+  millenium: { unit: 'month', factor: 12000 }
 };
 
 var helper = {};

--- a/test/spec/dataviews/helpers/histogram-helper.js
+++ b/test/spec/dataviews/helpers/histogram-helper.js
@@ -42,6 +42,21 @@ describe('dataview/helpers/histogram-helper', function () {
       var expected = 170107634;
       expect(actual).toBe(expected);
     });
+    it('should add decades properly', function () {
+      var actual = helper.add(12341234, 4, 'century');
+      var expected = 12635122034;
+      expect(actual).toBe(expected);
+    });
+    it('should add centuries properly', function () {
+      var actual = helper.add(12341234, 5, 'century');
+      var expected = 15790882034;
+      expect(actual).toBe(expected);
+    });
+    it('should add milleniums properly', function () {
+      var actual = helper.add(12341234, 2, 'millenium');
+      var expected = 63126245234;
+      expect(actual).toBe(expected);
+    });
     it('should throw an error for a wrong aggregation', function () {
       expect(function () {
         helper.add(12341234, 1, 'wrong');


### PR DESCRIPTION
To sync with the windshaft dateIntervalQueryTpl query at https://github.com/CartoDB/Windshaft-cartodb/blob/master/lib/cartodb/models/dataview/histograms/date-histogram.js#L131-L132.

Fixes #2161