### PR TITLE
Add 'visible' to layer options

### DIFF
--- a/src/api/v4/layer/layer.js
+++ b/src/api/v4/layer/layer.js
@@ -87,27 +87,18 @@ function Layer (source, style, options = {}) {
   _checkSource(source);
   _checkStyle(style);
 
-  options = _.defaults(options, {
-    visible: true,
-    featureClickColumns: [],
-    featureOverColumns: [],
-    minzoom: 0,
-    maxzoom: undefined,
-    aggregation: {}
-  });
-
   this._client = undefined;
   this._engine = undefined;
   this._internalModel = undefined;
 
   this._source = source;
   this._style = style;
-  this._visible = options.visible;
-  this._featureClickColumns = options.featureClickColumns;
-  this._featureOverColumns = options.featureOverColumns;
-  this._minzoom = options.minzoom;
-  this._maxzoom = options.maxzoom;
-  this._aggregation = options.aggregation;
+  this._visible = _.isBoolean(options.visible) ? options.visible : true;
+  this._featureClickColumns = options.featureClickColumns || [];
+  this._featureOverColumns = options.featureOverColumns || [];
+  this._minzoom = options.minzoom || 0;
+  this._maxzoom = options.maxzoom || undefined;
+  this._aggregation = options.aggregation || {};
 
   _validateAggregationColumnsAndInteractivity(this._aggregation.columns, this._featureClickColumns, this._featureOverColumns);
 }

--- a/test/spec/api/v4/layer/layer.spec.js
+++ b/test/spec/api/v4/layer/layer.spec.js
@@ -36,6 +36,14 @@ describe('api/v4/layer', function () {
       expect(id1).not.toEqual(id2);
     });
 
+    it('should be able to create a hidden layer', function () {
+      var layer = new carto.layer.Layer(source, style, {
+        visible: false
+      });
+
+      expect(layer.isHidden()).toBe(true);
+    });
+
     it('should build a new Layer params: (source, style, options)', function () {
       var layer = new carto.layer.Layer(source, style, {
         featureClickColumns: ['a', 'b'],


### PR DESCRIPTION
Related to: https://github.com/CartoDB/carto.js/issues/2004

### Description
This PR adds `visible` to the layer options so people can create layers that are hidden by default.

It also improves the examples a little bit.