### PR TITLE
Fix API key in quickstart example

### DIFF
--- a/docs/guides/quickstart-example.html
+++ b/docs/guides/quickstart-example.html
@@ -54,8 +54,8 @@
       }).addTo(map);
 
       var client = new carto.Client({
-              apiKey: 'YOUR_API_KEY',
-              username: 'cartojs-test'
+        apiKey: 'default_public',
+        username: 'cartojs-test'
       });
       const europeanCountriesDataset = new carto.source.Dataset(`
         ne_adm0_europe
@@ -198,8 +198,6 @@
       }
 
       client.addDataview(countriesDataview);
-
-
     </script>
   </body>
 </html

--- a/docs/guides/quickstart-example.html
+++ b/docs/guides/quickstart-example.html
@@ -200,4 +200,4 @@
       client.addDataview(countriesDataview);
     </script>
   </body>
-</html
+</html>


### PR DESCRIPTION
The example in the quickstart guide is not working because we're using `YOUR_API_KEY` instead of `default_public` as API key

https://carto.com/developers/carto-js/guides/quickstart/#conclusion