### PR TITLE
Improve reload

### DIFF
--- a/src/windshaft/client.js
+++ b/src/windshaft/client.js
@@ -122,8 +122,7 @@ WindshaftClient.prototype._isURLValid = function (url) {
 };
 
 WindshaftClient.prototype._post = function (url, payload, options) {
-  this._abortPreviousRequest();
-  this._previousRequest = $.ajax({
+  $.ajax({
     url: url,
     crossOrigin: true,
     method: 'POST',
@@ -136,8 +135,7 @@ WindshaftClient.prototype._post = function (url, payload, options) {
 };
 
 WindshaftClient.prototype._get = function (url, options) {
-  this._abortPreviousRequest();
-  this._previousRequest = $.ajax({
+  $.ajax({
     url: url,
     method: 'GET',
     dataType: 'jsonp',
@@ -146,12 +144,6 @@ WindshaftClient.prototype._get = function (url, options) {
     success: options.success,
     error: options.error
   });
-};
-
-WindshaftClient.prototype._abortPreviousRequest = function () {
-  if (this._previousRequest) {
-    this._previousRequest.abort();
-  }
 };
 
 WindshaftClient.prototype._getURL = function (params, method) {

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -773,7 +773,7 @@ describe('vis/vis', function () {
 
       this.vis.load(new VizJSON(this.vizjson));
       // Skip reload debouncer
-      this.vis._engine.reload = this.vis._engine._performReload;
+      this.vis._engine.DISABLE_DEBOUNCE = true;
       this.vis.instantiateMap();
       // Polling has started
       expect($.ajax.calls.argsFor(1)[0].url).toEqual('http://cdb.localhost.lan:8181/api/v1/map/9d7bf465e45113123bf9949c2a4f0395:0/analysis/node/e65b1ae05854aea96266808ec0686b91f3ee0a81');
@@ -873,7 +873,7 @@ describe('vis/vis', function () {
 
       this.vis.load(new VizJSON(this.vizjson));
       // Skip reload debouncer
-      this.vis._engine.reload = this.vis._engine._performReload;
+      this.vis._engine.DISABLE_DEBOUNCE = true;
       this.vis.instantiateMap();
     });
 
@@ -1015,7 +1015,7 @@ describe('vis/vis', function () {
 
       this.vis.load(new VizJSON(fakeVizJSON()));
       // Skip reload debouncer
-      this.vis._engine.reload = this.vis._engine._performReload;
+      this.vis._engine.DISABLE_DEBOUNCE = true;
       this.vis.instantiateMap();
 
       expect(this.vis.setOk).toHaveBeenCalled();
@@ -1041,7 +1041,7 @@ describe('vis/vis', function () {
 
       this.vis.load(new VizJSON(fakeVizJSON()));
       // Skip reload debouncer
-      this.vis._engine.reload = this.vis._engine._performReload;
+      this.vis._engine.DISABLE_DEBOUNCE = true;
       this.vis.instantiateMap();
 
       expect(this.vis.setOk).not.toHaveBeenCalled();

--- a/test/spec/windshaft/client.spec.js
+++ b/test/spec/windshaft/client.spec.js
@@ -229,47 +229,5 @@ describe('windshaft/client', function () {
         }.bind(this));
       });
     });
-
-    describe('cancelling previous requests', function () {
-      beforeEach(function () {
-        this.fakeXHR = jasmine.createSpyObj('fakeXHR', ['abort']);
-        $.ajax.and.returnValues(this.fakeXHR, undefined);
-      });
-
-      it('should cancel previous requests when using GET requests', function () {
-        var errorCallback = jasmine.createSpy('errorCallback');
-        var request = new Request({ some: 'json that must be encoded' }, {}, { error: errorCallback });
-        this.client.instantiateMap(request);
-
-        expect($.ajax.calls.argsFor(0)[0].method).toEqual('GET');
-        expect(this.fakeXHR.abort).not.toHaveBeenCalled();
-
-        this.client.instantiateMap(request);
-
-        expect(this.fakeXHR.abort).toHaveBeenCalled();
-
-        expect(errorCallback).not.toHaveBeenCalled();
-      });
-
-      it('should cancel previous requests when using POST requests', function (done) {
-        // simulate a compression that generates something BIG
-        spyOn(LZMA, 'compress').and.callFake(function (data, level, callback) {
-          callback(new Array(2500).join('x'));
-        });
-        var request = new Request({ something: new Array(3000).join('x') }, {}, {});
-        this.client.instantiateMap(request);
-
-        _.defer(function () {
-          expect($.ajax.calls.argsFor(0)[0].method).toEqual('POST');
-          expect(this.fakeXHR.abort).not.toHaveBeenCalled();
-
-          this.client.instantiateMap(request);
-
-          expect(this.fakeXHR.abort).toHaveBeenCalled();
-
-          done();
-        }.bind(this));
-      });
-    });
   });
 });


### PR DESCRIPTION
I realized that our requests system can be improved since we are still aborting prev requests, for example, when `reload` is called while waiting for a server response.

The following diagrams show the different states:

<br>

- **State 1**: No debounce, abort prev requests (Old)

<br>

![reload-1](https://user-images.githubusercontent.com/2227572/42572711-576fc512-851a-11e8-8696-4f204bf4224b.png)

<br>

- **State 2**: Debounce: global stack, abort prev requests (Current)

<br>

![reload-2](https://user-images.githubusercontent.com/2227572/42572718-5f46ef9a-851a-11e8-86fa-81651918e89e.png)

<br>

- **State 3**: Debounce: local stack, no abort prev requests (Proposed)

<br>

![reload-3](https://user-images.githubusercontent.com/2227572/42572728-6482b476-851a-11e8-87b9-d97348ff239a.png)

<br>

I would like to know if this is OK for our Windshaft servers cc @rochoa
