### PR TITLE
Fix torque

### DIFF
--- a/src/geo/torque-layer-view-base.js
+++ b/src/geo/torque-layer-view-base.js
@@ -199,10 +199,10 @@ var TorqueLayerViewBase = {
 
   _getQuery: function (layerModel) {
     var source = layerModel.get('source');
-    var query = source ? source.get('query') : '';
+    var query = source ? source.get('query') : 'select * from ' + layerModel.get('table_name');
     var qw = layerModel.get('sql_wrap');
     if (qw) {
-      query = _.template(qw)({ sql: query || ('select * from ' + layerModel.get('table_name')) });
+      query = _.template(qw)({ sql: query });
     }
     return query;
   }

--- a/src/geo/torque-layer-view-base.js
+++ b/src/geo/torque-layer-view-base.js
@@ -198,7 +198,8 @@ var TorqueLayerViewBase = {
   },
 
   _getQuery: function (layerModel) {
-    var query = layerModel.get('query');
+    var source = layerModel.get('source');
+    var query = source ? source.get('query') : '';
     var qw = layerModel.get('sql_wrap');
     if (qw) {
       query = _.template(qw)({ sql: query || ('select * from ' + layerModel.get('table_name')) });

--- a/test/spec/geo/torque-layer-view-base.spec.js
+++ b/test/spec/geo/torque-layer-view-base.spec.js
@@ -13,7 +13,7 @@ describe('geo/torque-layer-base-view', function () {
     engineMock = createEngine();
     this.model = new TorqueLayer({
       type: 'torque',
-      query: 'select * from table',
+      table_name: 'table',
       sql_wrap: 'select * from (<%= sql %>) as _cdbfromsqlwrap',
       query_wrapper: 'select * from (<%= sql %>) as _cdbfromquerywrapper',
       cartocss: 'Map {}',
@@ -22,15 +22,42 @@ describe('geo/torque-layer-base-view', function () {
   });
 
   describe('_getQuery', function () {
-    it('should take sql_wrap in case it is defined', function () {
-      var query = TorqueLayerViewBase._getQuery(this.model);
-      expect(query).toBe('select * from (select * from table) as _cdbfromsqlwrap');
+    describe('without source', function () {
+      it('should take sql_wrap in case it is defined', function () {
+        var query = TorqueLayerViewBase._getQuery(this.model);
+        expect(query).toBe('select * from (select * from table) as _cdbfromsqlwrap');
+      });
+
+      it('should not take query_wrapper in case sql_wrap is not defined', function () {
+        this.model.unset('sql_wrap');
+        var query = TorqueLayerViewBase._getQuery(this.model);
+        expect(query).toBe('select * from table');
+      });
     });
 
-    it('should not take query_wrapper in case sql_wrap is not defined', function () {
-      this.model.unset('sql_wrap');
-      var query = TorqueLayerViewBase._getQuery(this.model);
-      expect(query).toBe('select * from table');
+    describe('with source', function () {
+      var sourceMock = new Backbone.Model({
+        query: 'select * from new_table'
+      });
+
+      beforeEach(function () {
+        this.model.set('source', sourceMock);
+      });
+
+      it('should take sql_wrap in case it is defined', function () {
+        var query = TorqueLayerViewBase._getQuery(this.model);
+        expect(query).toBe('select * from (select * from new_table) as _cdbfromsqlwrap');
+      });
+
+      it('should not take query_wrapper in case sql_wrap is not defined', function () {
+        this.model.unset('sql_wrap');
+        var query = TorqueLayerViewBase._getQuery(this.model);
+        expect(query).toBe('select * from new_table');
+      });
+
+      afterEach(function () {
+        this.model.unset('source');
+      });
     });
   });
 


### PR DESCRIPTION
Related to: https://github.com/CartoDB/support/issues/1038

This PR uses the proper query from the source instead of a simple one. This fixes torque layers when analyses are made.

![fix-torque-analysis](https://user-images.githubusercontent.com/2227572/42628490-96c05130-85d0-11e8-9023-21b3027ddefb.gif)
