### PR TITLE
Use setView instead of flyTo to improve zoom transitions

### DIFF
--- a/src/geo/leaflet/leaflet-map-view.js
+++ b/src/geo/leaflet/leaflet-map-view.js
@@ -170,7 +170,7 @@ var LeafletMapView = MapView.extend({
 
   _setView: function () {
     if (this.map.hasChanged('zoom') || this.map.hasChanged('center')) {
-      this._leafletMap.flyTo(this.map.get('center'), this.map.get('zoom') || 0);
+      this._leafletMap.setView(this.map.get('center'), this.map.get('zoom') || 0);
     }
   },
 


### PR DESCRIPTION
#### Related to: https://github.com/CartoDB/cartodb/pull/14161

Get rid also of the tiles borders during zoom transitions with the +, - buttons.

| Bug |
|---|
| ![bug-buttons-zoom](https://user-images.githubusercontent.com/2227572/42696589-eb9b86c8-86b8-11e8-9663-3b4c009d6f38.gif) |

| Fix |
|---|
| ![fix-buttons-zoom](https://user-images.githubusercontent.com/2227572/42696627-0a2faac4-86b9-11e8-827b-1ed17d97c2cf.gif) |

