### PR TITLE
Fix popups/featureClick positions when scrolled

### DIFF
--- a/examples/acceptance/displaced-popups.html
+++ b/examples/acceptance/displaced-popups.html
@@ -1,0 +1,109 @@
+<html>
+  <head>
+    <title>Refactoria</title>
+    <meta name="viewport" content="initial-scale=1.0">
+    <meta charset="utf-8">
+    <link href="https://fonts.googleapis.com/css?family=Montserrat:400,600,700|Open+Sans:300,400,600" rel="stylesheet">
+    
+    <!-- Include Leaflet -->
+    <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
+    <link href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" rel="stylesheet">
+    
+    <!-- Include CARTO.js -->    
+    <script src="../../dist/public/carto.js"></script>
+
+    <style>
+      * {
+        box-sizing: border-box;
+      }
+      body, *{ margin: 0; padding: 0; }
+      #map {
+        position: absolute;
+        height: 400px;
+        width: 50%;
+        top: 100px;
+        z-index: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <span>Popups should position correctly even if page is scrolled</span>
+    <div id="map"></div>
+    <div style="height: 1200px; width: 3000px;"></div>
+
+    <script>
+      const map = L.map('map').setView([30, 0], 3);
+      map.scrollWheelZoom.disable();
+
+      L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager_nolabels/{z}/{x}/{y}.png', {
+        maxZoom: 18
+      }).addTo(map);
+
+      const client = new carto.Client({
+        apiKey: 'default_public',
+        username: 'cartojs-test'
+      });
+
+      const populatedPlacesSource = new carto.source.Dataset(`
+        ne_10m_populated_places_simple
+      `);
+      const populatedPlacesStyle = new carto.style.CartoCSS(`
+        #layer {
+          marker-width: 7;
+          marker-fill: #EE4D5A;
+          marker-line-color: #FFFFFF;
+        }
+      `);
+      const populatedPlacesLayer = new carto.layer.Layer(populatedPlacesSource, populatedPlacesStyle, {
+        featureOverColumns: ['name', 'pop_max', 'pop_min']
+      });
+
+      client.addLayer(populatedPlacesLayer);
+      client.getLeafletLayer().addTo(map);
+
+      const popup = L.popup({ closeButton: false });
+
+      function openPopup(featureEvent) {
+        let content = '<div class="widget">';
+
+        if (featureEvent.data.name) {
+          content += `<h2 class="h2">${featureEvent.data.name}</h2>`;
+        }
+
+        if (featureEvent.data.pop_max || featureEvent.data.pop_min) {
+          content += `<ul>`;
+
+          if (featureEvent.data.pop_max) {
+            content += `<li><h3>Max:</h3><p class="open-sans">${featureEvent.data.pop_max}</p></li>`;
+          }
+
+          if (featureEvent.data.pop_min) {
+            content += `<li><h3>Min:</h3><p class="open-sans">${featureEvent.data.pop_min}</p></li>`;
+          }
+
+          content += `</ul>`;
+        }
+
+        content += `</div>`;
+
+        popup.setContent(content);
+        popup.setLatLng(featureEvent.latLng);
+        if (!popup.isOpen()) {
+          popup.openOn(map);
+        }
+      }
+
+      function closePopup(featureEvent) {
+        popup.removeFrom(map);
+      }
+
+      function setPopupsClick() {
+        populatedPlacesLayer.off('featureOver');
+        populatedPlacesLayer.off('featureOut');
+        populatedPlacesLayer.on('featureClicked', openPopup);
+      }
+
+      setPopupsClick();
+    </script>
+  </body>
+</html>

--- a/src/geo/leaflet/leaflet-cartodb-layer-group-view.js
+++ b/src/geo/leaflet/leaflet-cartodb-layer-group-view.js
@@ -6,43 +6,6 @@ var CartoDBLayerGroupViewBase = require('../cartodb-layer-group-view-base');
 var zera = require('@carto/zera');
 var EMPTY_GIF = 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///yH5BAEAAAAALAAAAAABAAEAAAIBRAA7';
 
-var findContainerPoint = function (map, o) {
-  var curleft = 0;
-  var curtop = 0;
-  var obj = map.getContainer();
-
-  var x, y;
-  if (o.e.changedTouches && o.e.changedTouches.length > 0) {
-    x = o.e.changedTouches[0].clientX + window.scrollX;
-    y = o.e.changedTouches[0].clientY + window.scrollY;
-  } else {
-    x = o.e.clientX;
-    y = o.e.clientY;
-  }
-
-  // If the map is fixed at the top of the window, we can't use offsetParent
-  // cause there might be some scrolling that we need to take into account.
-  var point;
-  if (obj.offsetParent && obj.offsetTop > 0) {
-    do {
-      curleft += obj.offsetLeft;
-      curtop += obj.offsetTop;
-      obj = obj.offsetParent;
-    } while (obj);
-    point = new L.Point(
-      x - curleft, y - curtop);
-  } else {
-    var rect = obj.getBoundingClientRect();
-    var scrollX = (window.scrollX || window.pageXOffset);
-    var scrollY = (window.scrollY || window.pageYOffset);
-    point = new L.Point(
-      (o.e.clientX ? o.e.clientX : x) - rect.left - obj.clientLeft - scrollX,
-      (o.e.clientY ? o.e.clientY : y) - rect.top - obj.clientTop - scrollY);
-  }
-
-  return point;
-};
-
 var LeafletCartoDBLayerGroupView = function (layerModel, opts) {
   LeafletLayerView.apply(this, arguments);
   CartoDBLayerGroupViewBase.apply(this, arguments);
@@ -100,7 +63,7 @@ LeafletCartoDBLayerGroupView.prototype = _.extend(
     },
 
     _manageOnEvents: function (nativeMap, zeraEvent) {
-      var containerPoint = findContainerPoint(nativeMap, zeraEvent);
+      var containerPoint = nativeMap.layerPointToContainerPoint(zeraEvent.layerPoint);
 
       if (!containerPoint || isNaN(containerPoint.x) || isNaN(containerPoint.y)) {
         return false;


### PR DESCRIPTION
Related issue: https://github.com/CartoDB/support/issues/1659

So this has been broken since we introduced zera, but probably never seen it because we almost never have maps that are not full screen (iframes work just fine). I've attached an example that would be broken with the previous implementation if you scroll vertically or horizontally. Feel free to try it out on master.

I assume there's some difference between what we're getting with zera and what we used to get with wax. The thing is, there's apparently a Leaflet method that retrieves the containerPoint from the layerPoint, it seems to work perfectly.