### PR TITLE
Fix `Promise is undefined` in IE11

### DIFF
--- a/src/api/v4/index.js
+++ b/src/api/v4/index.js
@@ -20,7 +20,10 @@
 // Add polyfill for `fetch`
 require('whatwg-fetch');
 // Add polyfill for `Promise`
-require('promise-polyfill');
+var Promise = require('promise-polyfill');
+if (!window.Promise) {
+  window.Promise = Promise;
+}
 
 var Client = require('./client');
 var source = require('./source');

--- a/src/engine.js
+++ b/src/engine.js
@@ -37,7 +37,7 @@ var RELOAD_DEBOUNCE_TIME_IN_MILIS = 100;
  * @constructor
  */
 function Engine (params) {
-  if (!params) throw new Error('new Engine() called with no paramters');
+  if (!params) throw new Error('new Engine() called with no parameters');
   this._isNamedMap = params.templateName !== undefined;
 
   // Variables for the reload debounce

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,10 @@
 // Add polyfill for `fetch`
 require('whatwg-fetch');
 // Add polyfill for `Promise`
-require('promise-polyfill');
+var Promise = require('promise-polyfill');
+if (!window.Promise) {
+  window.Promise = Promise;
+}
 
 var cdb = require('./cartodb.js');
 

--- a/test/spec/engine.spec.js
+++ b/test/spec/engine.spec.js
@@ -23,7 +23,7 @@ describe('Engine', function () {
     it('should throw a descriptive error when called with no parameters', function () {
       expect(function () {
         new Engine(); // eslint-disable-line
-      }).toThrowError('new Engine() called with no paramters');
+      }).toThrowError('new Engine() called with no parameters');
     });
   });
 
@@ -245,7 +245,7 @@ describe('Engine', function () {
         var errorCallback = jasmine.createSpy('errorCallback');
 
         engineMock.reload({ error: errorCallback }).catch(function () {
-          var error = new WindshaftError({message: 'Postgis Plugin: ERROR:  transform: couldnt project point (242 611 0): latitude or longitude exceeded limits.'});
+          var error = new WindshaftError({ message: 'Postgis Plugin: ERROR:  transform: couldnt project point (242 611 0): latitude or longitude exceeded limits.' });
           expect(errorCallback).toHaveBeenCalledWith(error);
           done();
         });
@@ -263,7 +263,7 @@ describe('Engine', function () {
         var counter = 0;
         var NUM_CALLS = 2;
         function _process () {
-          var error = new WindshaftError({message: 'Postgis Plugin: ERROR:  transform: couldnt project point (242 611 0): latitude or longitude exceeded limits.'});
+          var error = new WindshaftError({ message: 'Postgis Plugin: ERROR:  transform: couldnt project point (242 611 0): latitude or longitude exceeded limits.' });
           expect(errorCallbacks[counter]).toHaveBeenCalledWith(error);
           counter++;
           (counter === NUM_CALLS) && done();
@@ -309,7 +309,7 @@ describe('Engine', function () {
 
         engineMock.on(Engine.Events.RELOAD_ERROR, spy);
         engineMock.reload().catch(function () {
-          var error = new WindshaftError({message: 'Postgis Plugin: ERROR:  transform: couldnt project point (242 611 0): latitude or longitude exceeded limits.'});
+          var error = new WindshaftError({ message: 'Postgis Plugin: ERROR:  transform: couldnt project point (242 611 0): latitude or longitude exceeded limits.' });
           expect(spy).toHaveBeenCalledWith(error);
           done();
         });


### PR DESCRIPTION
### Related to https://github.com/CartoDB/carto.js/issues/2180

### Context
**promise-polyfill** was included but not linked from `engine.js`, causing the reported exception. Adding `var Promise = require('promise-polyfill');` in that file fixed the error, but then another error raised, as `Promise` is also used from **whatwg-fetch** polyfill

### Fix
Add `Promise` to `window`, so it is widely available and no errors are thrown in IE11.

> Note: This should be a patch, to be deployed to npm and our CDN