### PR TITLE
Fix safari drag problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "browserify-shim": "3.8.12",
     "camshaft-reference": "0.34.0",
     "carto": "cartodb/carto#master",
-    "@carto/zera": "1.0.6",
+    "@carto/zera": "cartodb/zera#fix-drag-safari",
     "clip-path-polygon": "0.1.12",
     "d3-array": "1.2.1",
     "d3-format": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "browserify-shim": "3.8.12",
     "camshaft-reference": "0.34.0",
     "carto": "cartodb/carto#master",
-    "@carto/zera": "cartodb/zera#fix-drag-safari",
+    "@carto/zera": "CartoDB/zera#fix-drag-safari",
     "clip-path-polygon": "0.1.12",
     "d3-array": "1.2.1",
     "d3-format": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "browserify-shim": "3.8.12",
     "camshaft-reference": "0.34.0",
     "carto": "cartodb/carto#master",
-    "@carto/zera": "1.0.6-staging.2",
+    "@carto/zera": "1.0.7",
     "clip-path-polygon": "0.1.12",
     "d3-array": "1.2.1",
     "d3-format": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "browserify-shim": "3.8.12",
     "camshaft-reference": "0.34.0",
     "carto": "cartodb/carto#master",
-    "@carto/zera": "CartoDB/zera#fix-drag-safari",
+    "@carto/zera": "1.0.6-staging.2",
     "clip-path-polygon": "0.1.12",
     "d3-array": "1.2.1",
     "d3-format": "1.2.0",

--- a/src/vis/vis-view.js
+++ b/src/vis/vis-view.js
@@ -51,7 +51,11 @@ var Vis = View.extend({
     this.$el.html(this.mapView.el);
 
     // Bind events before the view is rendered and layer views are added to the map
-    this.mapView.bind('newLayerView', this._bindLayerViewToLoader, this);
+    this.listenTo(this.mapView, 'newLayerView', this._bindLayerViewToLoader);
+    // Trigger click event in map model
+    this.listenTo(this.mapView, 'click', function () {
+      this.model.trigger('click');
+    });
     this.mapView.render();
   },
 

--- a/test/spec/api/v4/source/dataset.spec.js
+++ b/test/spec/api/v4/source/dataset.spec.js
@@ -2,6 +2,17 @@ const Base = require('../../../../../src/api/v4/source/base');
 const carto = require('../../../../../src/api/v4');
 
 describe('api/v4/source/dataset', function () {
+  var originalTimeout;
+
+  beforeEach(function () {
+    originalTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 10000;
+  });
+
+  afterEach(function () {
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = originalTimeout;
+  });
+
   describe('constructor', function () {
     it('should return a new Dataset object', function () {
       var populatedPlacesDataset = new carto.source.Dataset('ne_10m_populated_places_simple');


### PR DESCRIPTION
Related to: https://github.com/CartoDB/cartodb/issues/14115

### Description
This PR fixes a bug introduced in https://github.com/CartoDB/zera/commit/317a82f61b137299f6b959b2addc65c52dd11df0 while trying to fix https://github.com/CartoDB/carto.js/issues/1952

The problem is that Builder is listening directly to document click events, so it closes the edit button as soon as soon as it's shown. Instead of stopping the event propagation to avoid that error we're going to handle it using carto.js events and stop listening to document click.
