### PR TITLE
Rename http to https in CARTO CDN lib scripts and styles

### DIFF
--- a/examples/TheHobbitLocations/index.html
+++ b/examples/TheHobbitLocations/index.html
@@ -2,7 +2,7 @@
   <head>
     <title>THE HOBBIT FILMING LOCATIONS - A Cartodb.js map</title>
     <link href="css/reset.css" rel="stylesheet" type="text/css" />
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" /> 
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
     <link href="css/style.css" rel="stylesheet" type="text/css" />
   </head>
 
@@ -53,7 +53,7 @@
     </script>
 
     <!--Include the js. Please be sure that you use a locked version in case you go to production-->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
     <script type="text/javascript" src="js/app.js"></script>
 
   </body>

--- a/examples/add_custom_searchbox.html
+++ b/examples/add_custom_searchbox.html
@@ -6,11 +6,11 @@
 <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
 <style>
   html, body,#map {
-      width:100%; 
-      height:100%; 
-      padding: 0; 
+      width:100%;
+      height:100%;
+      padding: 0;
       margin: 0;
-      
+
     }
   div#searchbox{
     background-color: #d2eaef;
@@ -29,7 +29,7 @@
       width: 200px;
     }
  </style>
-   <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+   <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
 
   </head>
 <body>
@@ -38,11 +38,11 @@
   <input type="text" name="ad" value="" id="ad" size="10" />
   <button type="button" id="searchButton">Search</button>
 
-<script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+<script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 <script>
   var input;
   function main () {
-    
+
     var layerUrl = 'https://documentation.carto.com/api/v2/viz/34dfd2e4-d62b-11e5-b5e7-0ea31932ec1d/viz.json';
 
     // add CartoDB layer
@@ -65,10 +65,10 @@
           });
         });
        })
-        
+
   }
 
-  
+
   window.onload = main;
 
 </script>

--- a/examples/annotations.html
+++ b/examples/annotations.html
@@ -13,13 +13,13 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       function main() {

--- a/examples/basemap.html
+++ b/examples/basemap.html
@@ -32,7 +32,7 @@
       var basemap = {
         type: "http",
         options: {
-          urlTemplate: "http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+          urlTemplate: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
           subdomains: ["a", "b", "c"]
         }
       };

--- a/examples/basemap.html
+++ b/examples/basemap.html
@@ -27,7 +27,7 @@
       }
     </style>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
       var basemap = {
         type: "http",

--- a/examples/bing.html
+++ b/examples/bing.html
@@ -10,11 +10,11 @@
           margin: 0;
         }
       </style>
-      <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
+      <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
       <script type="text/javascript" src="http://ecn.dev.virtualearth.net/mapcontrol/mapcontrol.ashx?v=7.0"></script>
       <script type="text/javascript">
       var map = null;
-            
+
       function getMap()
       {
           map = new Microsoft.Maps.Map(document.getElementById('myMap'), {credentials: 'Your Bing Maps Key'});
@@ -37,16 +37,16 @@
               },
               width: 256,
               height: 256
-            };  
-            var tileSource = new Microsoft.Maps.TileSource(options); 
-            var tilelayer= new Microsoft.Maps.TileLayer({ mercator: tileSource}); 
-            map.entities.push(tilelayer);  
+            };
+            var tileSource = new Microsoft.Maps.TileSource(options);
+            var tilelayer= new Microsoft.Maps.TileLayer({ mercator: tileSource});
+            map.entities.push(tilelayer);
           });
-      }   
+      }
       </script>
    </head>
    <body onload="getMap();">
       <div id='myMap' style="position:relative; width:100%; height:100%;"></div>
    </body>
 </html>
-      
+

--- a/examples/bing.html
+++ b/examples/bing.html
@@ -11,7 +11,7 @@
         }
       </style>
       <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
-      <script type="text/javascript" src="http://ecn.dev.virtualearth.net/mapcontrol/mapcontrol.ashx?v=7.0"></script>
+      <script type="text/javascript" src="https://ecn.dev.virtualearth.net/mapcontrol/mapcontrol.ashx?v=7.0"></script>
       <script type="text/javascript">
       var map = null;
 

--- a/examples/bounds.html
+++ b/examples/bounds.html
@@ -2,8 +2,8 @@
 <html>
   <head>
     <title>Set Bounds example | CartoDB.js</title>
-    <!--  
-      This example shows you how to get a bounding box for a feature from CartoDB 
+    <!--
+      This example shows you how to get a bounding box for a feature from CartoDB
       and move your map according to that bbox.
     -->
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
@@ -18,19 +18,19 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
-    
+
       var layer;
       function main() {
-        var map = L.map('map', { 
+        var map = L.map('map', {
           zoomControl: false,
           center: [53, 20],
           zoom: 3

--- a/examples/callback_layer.html
+++ b/examples/callback_layer.html
@@ -12,13 +12,13 @@
         margin: 0;
       }
     </style>
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
-    
+
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script src="http://d3js.org/queue.v1.min.js"></script>
 
     <script>

--- a/examples/callback_layer.html
+++ b/examples/callback_layer.html
@@ -19,7 +19,7 @@
 
     <!-- include cartodb.js library -->
     <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
-    <script src="http://d3js.org/queue.v1.min.js"></script>
+    <script src="https://d3js.org/queue.v1.min.js"></script>
 
     <script>
       function main() {
@@ -32,8 +32,8 @@
           attribution: 'Stamen'
         }).addTo(map);
         var layers = [
-          'http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json',
-          'http://documentation.cartodb.com/api/v2/viz/236085de-ea08-11e2-958c-5404a6a683d5/viz.json'
+          'https://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json',
+          'https://documentation.cartodb.com/api/v2/viz/236085de-ea08-11e2-958c-5404a6a683d5/viz.json'
           // add here more layers
         ]
         var q = queue(3);

--- a/examples/core.html
+++ b/examples/core.html
@@ -42,7 +42,7 @@
         layers: [{
           type: "http",
           options: {
-            urlTemplate: "http://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
+            urlTemplate: "https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
             subdomains: [ "a", "b", "c" ]
           }
         }, {
@@ -76,8 +76,8 @@
 
       /* 2: Another option: with a vizjson defined in the CartoDB editor */
       var vizjsons = [
-        { zoom: 2,  url: "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json" },
-        { zoom: 17, url: "http://documentation.cartodb.com/api/v2/viz/c3dd77a6-d5e4-11e3-a5b4-0e73339ffa50/viz.json" },
+        { zoom: 2,  url: "https://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json" },
+        { zoom: 17, url: "https://documentation.cartodb.com/api/v2/viz/c3dd77a6-d5e4-11e3-a5b4-0e73339ffa50/viz.json" },
         { zoom: 12, url: "https://documentation.cartodb.com/api/v2/viz/df45a412-d5dc-11e3-855b-0e10bcd91c2b/viz.json" },
         { zoom: 2,  url: "https://documentation.cartodb.com/api/v2/viz/e7132460-d5e8-11e3-8459-0e10bcd91c2b/viz.json" },
         { basemap:"dark_nolabels", zoom: 8, url: "https://documentation.cartodb.com/api/v2/viz/d5c2419c-d08d-11e3-80a5-0e230854a1cb/viz.json" },

--- a/examples/core.html
+++ b/examples/core.html
@@ -27,7 +27,7 @@
       }
     </style>
 
-    <script src="http://www.google.com/jsapi"></script>
+    <script src="https://www.google.com/jsapi"></script>
     <script>google.load("jquery", "1.7.1");</script>
 
     <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>

--- a/examples/core.html
+++ b/examples/core.html
@@ -30,7 +30,7 @@
     <script src="http://www.google.com/jsapi"></script>
     <script>google.load("jquery", "1.7.1");</script>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
     <script>
 
       /* 1: We can create an image using a custom build layer definition: */

--- a/examples/createLayer_custom_tooltip.html
+++ b/examples/createLayer_custom_tooltip.html
@@ -39,7 +39,7 @@
 
       var map = new L.Map('map', {center: [20, 20], zoom: 2});
 
-      L.tileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
+      L.tileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
         attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
       }).addTo(map);
 

--- a/examples/createLayer_custom_tooltip.html
+++ b/examples/createLayer_custom_tooltip.html
@@ -5,15 +5,15 @@
   <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
   <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
 
-  <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
-  <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+  <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+  <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
   <style>
     html, body,#map {
-      width:100%; 
-      height:100%; 
-      padding: 0; 
-      margin: 0;      
+      width:100%;
+      height:100%;
+      padding: 0;
+      margin: 0;
     }
 
   </style>
@@ -31,39 +31,39 @@
     </div>
   </div>
   </script>
-  
+
   <div id='map'></div>
-  
+
   <script type="text/javascript">
     function main() {
 
       var map = new L.Map('map', {center: [20, 20], zoom: 2});
-            
+
       L.tileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
         attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
       }).addTo(map);
-        
+
       cartodb.createLayer(map, 'http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json')
         .addTo(map)
         .on('done', function(layer) {
           //do stuff
-          //layer.setZIndex(100); 
+          //layer.setZIndex(100);
           var sublayer = layer.getSubLayer(0);
 
           sublayer.setInteractivity('cartodb_id, name, pop2005');
-                   
+
           // tooltip definition for createLayer()
           var testTooltip = layer.leafletMap.viz.addOverlay({
             type: 'tooltip',
             layer: sublayer,
-            template: $('#tooltip_template').html(), 
+            template: $('#tooltip_template').html(),
             width: 200,
             position: 'bottom|right',
             fields: [{ name: 'name', population: 'pop2005' }]
           });
           $('body').append(testTooltip.render().el);
-          
-        });        
+
+        });
     }
     window.onload = main;
   </script>

--- a/examples/createLayer_custom_tooltip.html
+++ b/examples/createLayer_custom_tooltip.html
@@ -40,14 +40,13 @@
       var map = new L.Map('map', {center: [20, 20], zoom: 2});
 
       L.tileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', {
-        attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+        attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution/">CartoDB</a>'
       }).addTo(map);
 
       cartodb.createLayer(map, 'http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json')
         .addTo(map)
         .on('done', function(layer) {
           //do stuff
-          //layer.setZIndex(100);
           var sublayer = layer.getSubLayer(0);
 
           sublayer.setInteractivity('cartodb_id, name, pop2005');

--- a/examples/createLayer_noLegend.html
+++ b/examples/createLayer_noLegend.html
@@ -4,7 +4,7 @@
   <title>CartoTemplate | CartoDB</title>
   <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
   <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-  <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
+  <link rel="shortcut icon" href="https://carto.com/favicon.ico" />
 
   <style>
     html, body, #map {
@@ -43,7 +43,7 @@
   });
 
   L.tileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
-    {attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
+    {attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution/">CartoDB</a>'
   }).addTo(map);
 
   cartodb.createLayer(map, mapUrl,{

--- a/examples/createLayer_noLegend.html
+++ b/examples/createLayer_noLegend.html
@@ -42,7 +42,7 @@
     center:[0,0]
   });
 
-  L.tileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
+  L.tileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
     {attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
   }).addTo(map);
 

--- a/examples/createLayer_noLegend.html
+++ b/examples/createLayer_noLegend.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
   <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
   <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
-  
+
   <style>
     html, body, #map {
       height: 100%;
@@ -15,8 +15,8 @@
 
   </style>
 
-  <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
-  <!-- 
+  <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+  <!--
   <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   -->
 </head>
@@ -25,15 +25,15 @@
   <div id="map"></div>
 
   <!-- include cartodb.js library -->
-  <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+  <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
   <!--
-  <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script> 
+  <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script>
   -->
-     
-  
+
+
   <!-- Drop your code between the script tags below! -->
   <script>
-  
+
   mapUrl='https://documentation.cartodb.com/api/v2/viz/34dfd2e4-d62b-11e5-b5e7-0ea31932ec1d/viz.json'
 
 
@@ -42,7 +42,7 @@
     center:[0,0]
   });
 
-  L.tileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', 
+  L.tileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
     {attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
   }).addTo(map);
 
@@ -54,7 +54,7 @@
       //do stuff
       console.log('legends active :'+ layer.options.legends);
     });
-  
+
   </script>
 
 </body>

--- a/examples/createLayer_refresh_time.html
+++ b/examples/createLayer_refresh_time.html
@@ -5,7 +5,7 @@
   <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
   <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
   <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
-  
+
   <style>
     html, body, #map {
       height: 100%;
@@ -17,8 +17,8 @@
     }*/
   </style>
 
-  <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
-  <!-- 
+  <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+  <!--
   <link rel="stylesheet" href="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   -->
 </head>
@@ -27,23 +27,23 @@
   <div id="map"></div>
 
   <!-- include cartodb.js library -->
-  <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+  <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
   <!--
-  <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script> 
+  <script src="https://cartodb-libs.global.ssl.fastly.net/cartodb.js/v3/3.15/cartodb.js"></script>
   -->
-     
-  
+
+
   <!-- Drop your code between the script tags below! -->
   <script>
 
   mapUrl='https://team.cartodb.com/u/ernestomb/api/v2/viz/066ff802-a580-11e5-a9bb-0e3ff518bd15/viz.json'
-  
+
   map= new L.Map('map', {
     zoom:9,
     center:[40.5,-3.6]
   });
 
-  L.tileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png', 
+  L.tileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
     {attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
   }).addTo(map);
 
@@ -54,7 +54,7 @@
   .done(function(layer){
       //do stuff
     });
-  
+
   </script>
 
 </body>

--- a/examples/createLayer_refresh_time.html
+++ b/examples/createLayer_refresh_time.html
@@ -43,7 +43,7 @@
     center:[40.5,-3.6]
   });
 
-  L.tileLayer('http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
+  L.tileLayer('https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
     {attribution: '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="http://cartodb.com/attributions">CartoDB</a>'
   }).addTo(map);
 

--- a/examples/cursor_interaction.html
+++ b/examples/cursor_interaction.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <title>Adding Cursor interaction to your map example | CartoDB.js</title>
-    <!--  
+    <!--
       This example shows you how to add cursor interaction to your map using CartoDB.js
     -->
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
@@ -16,13 +16,13 @@
         background-color: #E5F5F7;
       }
     </style>
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
-    
+
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.uncompressed.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.uncompressed.js"></script>
 
     <script>
 

--- a/examples/custom.html
+++ b/examples/custom.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <title>Legends | CartoDB.js</title>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" /> 
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
       window.onload = function() {
@@ -37,7 +37,7 @@
 
           };
 
-          cartodb.createVis('map', map_viz_url, { 
+          cartodb.createVis('map', map_viz_url, {
             legends: false,
             zoom: 3,
             no_cdn: true

--- a/examples/easy.html
+++ b/examples/easy.html
@@ -13,13 +13,13 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       function main() {

--- a/examples/filters-template/index.html
+++ b/examples/filters-template/index.html
@@ -9,18 +9,18 @@
     <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
     <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/normalize/2.1.3/normalize.min.css">
     <link rel="stylesheet" href="main.css">
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
-    
+
     <div id="filters">
       <ul></ul>
     </div>
-    
+
     <script src="http:////ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
     <script>window.jQuery || document.write('<script src="js/vendor/jquery-1.10.2.min.js"><\/script>')</script>
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
     <script src="main.js"></script>
   </body>
 </html>

--- a/examples/format.html
+++ b/examples/format.html
@@ -27,7 +27,7 @@
       }
     </style>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
   </head>
   <body>
     <div id="content">

--- a/examples/gmaps/gmaps_driving_directions_plus_sql_api.html
+++ b/examples/gmaps/gmaps_driving_directions_plus_sql_api.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.30"></script>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.12/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.12/cartodb.js"></script>
 
     <script>
       var map;
@@ -33,7 +33,7 @@
         var myLatlng = new google.maps.LatLng(37.753, -122.433);
         var myOptions = {
           zoom: 13,
-          center: myLatlng, 
+          center: myLatlng,
           disableDefaultUI: true,
           mapTypeId: google.maps.MapTypeId.ROADMAP
         }

--- a/examples/gmaps/gmaps_heatmap_plus_sql_api.html
+++ b/examples/gmaps/gmaps_heatmap_plus_sql_api.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
@@ -22,7 +22,7 @@
     <script src="https://maps.googleapis.com/maps/api/js?v=3.30&libraries=visualization"></script>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.12/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.12/cartodb.js"></script>
 
     <script>
       var map, pointarray, heatmap;
@@ -33,7 +33,7 @@
         var myLatlng = new google.maps.LatLng(40.722, -73.997);
         var myOptions = {
           zoom: 14,
-          center: myLatlng, 
+          center: myLatlng,
           disableDefaultUI: true,
           mapTypeId: google.maps.MapTypeId.SATELLITE
         }
@@ -44,7 +44,7 @@
         var sql = cartodb.SQL({ user: 'andrew', format: 'geojson'});
         sql.execute("SELECT cartodb_id, the_geom FROM cleveland_spring_points").done(function(data) {
           data = data.features.map(function(r) {
-              return new google.maps.LatLng(r.geometry.coordinates[1], r.geometry.coordinates[0]) 
+              return new google.maps.LatLng(r.geometry.coordinates[1], r.geometry.coordinates[0])
             });
           var pointArray = new google.maps.MVCArray(data);
           heatmap = new google.maps.visualization.HeatmapLayer({

--- a/examples/gmaps/gmaps_satellite.html
+++ b/examples/gmaps/gmaps_satellite.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>

--- a/examples/gmaps/gmaps_with_torque.html
+++ b/examples/gmaps/gmaps_with_torque.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.30"></script>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.12/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.12/cartodb.js"></script>
 
     <script>
       function main() {

--- a/examples/gmaps_driving_directions_plus_sql_api.html
+++ b/examples/gmaps_driving_directions_plus_sql_api.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.30"></script>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       var map;
@@ -33,7 +33,7 @@
         var myLatlng = new google.maps.LatLng(37.753, -122.433);
         var myOptions = {
           zoom: 13,
-          center: myLatlng, 
+          center: myLatlng,
           disableDefaultUI: true,
           mapTypeId: google.maps.MapTypeId.ROADMAP
         }

--- a/examples/gmaps_force_basemap.html
+++ b/examples/gmaps_force_basemap.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.30"></script>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       function main() {

--- a/examples/gmaps_heatmap_plus_sql_api.html
+++ b/examples/gmaps_heatmap_plus_sql_api.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
@@ -22,7 +22,7 @@
     <script src="https://maps.googleapis.com/maps/api/js?v=3.30&libraries=visualization"></script>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       var map, pointarray, heatmap;
@@ -33,7 +33,7 @@
         var myLatlng = new google.maps.LatLng(40.722, -73.997);
         var myOptions = {
           zoom: 14,
-          center: myLatlng, 
+          center: myLatlng,
           disableDefaultUI: true,
           mapTypeId: google.maps.MapTypeId.SATELLITE
         }
@@ -44,7 +44,7 @@
         var sql = cartodb.SQL({ user: 'andrew', format: 'geojson'});
         sql.execute("SELECT cartodb_id, the_geom FROM cleveland_spring_points").done(function(data) {
           data = data.features.map(function(r) {
-              return new google.maps.LatLng(r.geometry.coordinates[1], r.geometry.coordinates[0]) 
+              return new google.maps.LatLng(r.geometry.coordinates[1], r.geometry.coordinates[0])
             });
           var pointArray = new google.maps.MVCArray(data);
           heatmap = new google.maps.visualization.HeatmapLayer({

--- a/examples/gmaps_satellite.html
+++ b/examples/gmaps_satellite.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>

--- a/examples/gmaps_with_torque.html
+++ b/examples/gmaps_with_torque.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="http://www.maps.google.com/maps/api/js?sensor=false&v=3.30"></script>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       function main() {

--- a/examples/header_overlay.html
+++ b/examples/header_overlay.html
@@ -24,13 +24,13 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.14/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.14/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.14/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.14/cartodb.js"></script>
 
     <script>
       function main() {

--- a/examples/image.html
+++ b/examples/image.html
@@ -27,7 +27,7 @@
       }
     </style>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
       /* 1: We can create an image using a custom build layer definition: */

--- a/examples/image.html
+++ b/examples/image.html
@@ -39,7 +39,7 @@
         layers: [{
           type: "http",
           options: {
-            urlTemplate: "http://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
+            urlTemplate: "https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
             subdomains: [ "a", "b", "c" ]
           }
         }, {
@@ -74,15 +74,15 @@
       var basemap = {
         type: "http",
         options: {
-          urlTemplate: "http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+          urlTemplate: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
           subdomains: ["a", "b", "c"]
         }
       };
 
       /* 2: Another option: with a vizjson defined in the CartoDB editor */
       var vizjsons = [
-        { zoom: 2,  url: "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json" },
-        { zoom: 17, url: "http://documentation.cartodb.com/api/v2/viz/c3dd77a6-d5e4-11e3-a5b4-0e73339ffa50/viz.json" },
+        { zoom: 2,  url: "https://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json" },
+        { zoom: 17, url: "https://documentation.cartodb.com/api/v2/viz/c3dd77a6-d5e4-11e3-a5b4-0e73339ffa50/viz.json" },
         { zoom: 12, url: "https://documentation.cartodb.com/api/v2/viz/df45a412-d5dc-11e3-855b-0e10bcd91c2b/viz.json" },
         { zoom: 2,  url: "https://documentation.cartodb.com/api/v2/viz/e7132460-d5e8-11e3-8459-0e10bcd91c2b/viz.json" },
         { zoom: 8,  url: "https://documentation.cartodb.com/api/v2/viz/d5c2419c-d08d-11e3-80a5-0e230854a1cb/viz.json" },

--- a/examples/images/basemap.html
+++ b/examples/images/basemap.html
@@ -32,7 +32,7 @@
       var basemap = {
         type: "http",
         options: {
-          urlTemplate: "http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+          urlTemplate: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
           subdomains: ["a", "b", "c"]
         }
       };

--- a/examples/images/basemap.html
+++ b/examples/images/basemap.html
@@ -27,7 +27,7 @@
       }
     </style>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
     <script>
       var basemap = {
         type: "http",

--- a/examples/images/core.html
+++ b/examples/images/core.html
@@ -42,7 +42,7 @@
         layers: [{
           type: "http",
           options: {
-            urlTemplate: "http://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
+            urlTemplate: "https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
             subdomains: [ "a", "b", "c" ]
           }
         }, {
@@ -76,8 +76,8 @@
 
       /* 2: Another option: with a vizjson defined in the CartoDB editor */
       var vizjsons = [
-        { zoom: 2,  url: "http://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json" },
-        { zoom: 17, url: "http://documentation.cartodb.com/api/v2/viz/c3dd77a6-d5e4-11e3-a5b4-0e73339ffa50/viz.json" },
+        { zoom: 2,  url: "https://documentation.cartodb.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json" },
+        { zoom: 17, url: "https://documentation.cartodb.com/api/v2/viz/c3dd77a6-d5e4-11e3-a5b4-0e73339ffa50/viz.json" },
         { zoom: 12, url: "https://documentation.cartodb.com/api/v2/viz/df45a412-d5dc-11e3-855b-0e10bcd91c2b/viz.json" },
         { zoom: 2,  url: "https://documentation.cartodb.com/api/v2/viz/e7132460-d5e8-11e3-8459-0e10bcd91c2b/viz.json" },
         { basemap:"dark_nolabels", zoom: 8, url: "https://documentation.cartodb.com/api/v2/viz/d5c2419c-d08d-11e3-80a5-0e230854a1cb/viz.json" },

--- a/examples/images/core.html
+++ b/examples/images/core.html
@@ -30,7 +30,7 @@
     <script src="http://www.google.com/jsapi"></script>
     <script>google.load("jquery", "1.7.1");</script>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.core.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.core.js"></script>
     <script>
 
       /* 1: We can create an image using a custom build layer definition: */

--- a/examples/images/core.html
+++ b/examples/images/core.html
@@ -27,7 +27,7 @@
       }
     </style>
 
-    <script src="http://www.google.com/jsapi"></script>
+    <script src="https://www.google.com/jsapi"></script>
     <script>google.load("jquery", "1.7.1");</script>
 
     <script src="https://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.core.js"></script>

--- a/examples/images/format.html
+++ b/examples/images/format.html
@@ -27,7 +27,7 @@
       }
     </style>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
   </head>
   <body>
     <div id="content">

--- a/examples/images/image.html
+++ b/examples/images/image.html
@@ -39,7 +39,7 @@
         layers: [{
           type: "http",
           options: {
-            urlTemplate: "http://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
+            urlTemplate: "https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
             subdomains: [ "a", "b", "c" ]
           }
         }, {
@@ -74,7 +74,7 @@
       var basemap = {
         type: "http",
         options: {
-          urlTemplate: "http://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
+          urlTemplate: "https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}.png",
           subdomains: ["a", "b", "c"]
         }
       };

--- a/examples/images/layer_definition.html
+++ b/examples/images/layer_definition.html
@@ -40,7 +40,7 @@
         layers: [{
           type: "http",
           options: {
-            urlTemplate: "http://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
+            urlTemplate: "https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
             subdomains: [ "a", "b", "c" ]
           }
         }, {

--- a/examples/images/layer_definition.html
+++ b/examples/images/layer_definition.html
@@ -28,7 +28,7 @@
       .map img { display: none; }
     </style>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
     <script>
 
       /* 1: We can create an image using a custom build layer definition: */

--- a/examples/images/plain-color.html
+++ b/examples/images/plain-color.html
@@ -28,7 +28,7 @@
       .map img { display: none; }
     </style>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
     <script>
 
       var layer_definition = {

--- a/examples/images/single-image.html
+++ b/examples/images/single-image.html
@@ -26,7 +26,7 @@
         background-color: #f8f8f8;
       }
     </style>
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
   </head>
   <body>
     <div id="content">

--- a/examples/images/torque.html
+++ b/examples/images/torque.html
@@ -28,7 +28,7 @@
       .map img { display: none; }
     </style>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
     <script>
 
       cartodb.Image("http://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json").size(500, 500).getUrl(function(error, url) {

--- a/examples/images/torque.html
+++ b/examples/images/torque.html
@@ -31,7 +31,7 @@
     <script src="https://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
     <script>
 
-      cartodb.Image("http://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json").size(500, 500).getUrl(function(error, url) {
+      cartodb.Image("https://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json").size(500, 500).getUrl(function(error, url) {
 
         var img = new Image();
 

--- a/examples/images/torque_step.html
+++ b/examples/images/torque_step.html
@@ -31,7 +31,7 @@
     <script src="https://libs.cartocdn.com/cartodb.js/v3/3.14/cartodb.js"></script>
     <script>
 
-      cartodb.Image("http://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json", { step: 100 }).size(500, 500).getUrl(function(error, url) {
+      cartodb.Image("https://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json", { step: 100 }).size(500, 500).getUrl(function(error, url) {
 
         var img = new Image();
 

--- a/examples/images/torque_step.html
+++ b/examples/images/torque_step.html
@@ -28,7 +28,7 @@
       .map img { display: none; }
     </style>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.14/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.14/cartodb.js"></script>
     <script>
 
       cartodb.Image("http://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json", { step: 100 }).size(500, 500).getUrl(function(error, url) {

--- a/examples/index.html
+++ b/examples/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <title>Legends | CartoDB.js</title>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" /> 
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
       currentLegend = null;
@@ -32,7 +32,7 @@
 
           currentLegend = stackedLegend;
 
-        } else { 
+        } else {
 
           $(".legend-selector a.selected").removeClass("selected");
           $link.addClass("selected");

--- a/examples/infowindow-on-hover.html
+++ b/examples/infowindow-on-hover.html
@@ -13,13 +13,13 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       function main() {

--- a/examples/infowindow-with-different-positioning.html
+++ b/examples/infowindow-with-different-positioning.html
@@ -35,7 +35,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map1"></div>
@@ -43,7 +43,7 @@
     <div id="map2"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       function main() {

--- a/examples/layer_definition.html
+++ b/examples/layer_definition.html
@@ -28,7 +28,7 @@
       .map img { display: none; }
     </style>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
       /* 1: We can create an image using a custom build layer definition: */

--- a/examples/layer_definition.html
+++ b/examples/layer_definition.html
@@ -40,7 +40,7 @@
         layers: [{
           type: "http",
           options: {
-            urlTemplate: "http://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
+            urlTemplate: "https://{s}.basemaps.cartocdn.com/dark_nolabels/{z}/{x}/{y}.png",
             subdomains: [ "a", "b", "c" ]
           }
         }, {

--- a/examples/layer_selector.html
+++ b/examples/layer_selector.html
@@ -43,7 +43,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
@@ -58,7 +58,7 @@
     </div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       // create layer selector

--- a/examples/layer_selector_overlay.html
+++ b/examples/layer_selector_overlay.html
@@ -14,14 +14,14 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
-    
+
   <body>
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
 

--- a/examples/layer_toggle.html
+++ b/examples/layer_toggle.html
@@ -24,7 +24,7 @@
         color: #333;
       }
     </style>
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
 
@@ -35,12 +35,12 @@
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
 
       function main() {
-        var map = new L.Map('map', { 
+        var map = new L.Map('map', {
           zoomControl: false,
           center: [43, 0],
           zoom: 3

--- a/examples/leaflet.html
+++ b/examples/leaflet.html
@@ -12,13 +12,13 @@
         margin: 0;
       }
     </style>
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
-    
+
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       function main() {

--- a/examples/leaflet_control_multilayer2.html
+++ b/examples/leaflet_control_multilayer2.html
@@ -12,13 +12,13 @@
       margin: 0;
     }
   </style>
-  <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+  <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
 </head>
 <body>
   <div id="map"></div>
 
   <!-- include cartodb.js library -->
-  <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+  <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
   <script>
     function main() {
@@ -45,7 +45,7 @@
         .done(function(layer)
         {
           layer2 = layer;
-          
+
           var overlayMaps = {
             "Layer1": layer1,
             "Layer2": layer2

--- a/examples/leaflet_core_library.html
+++ b/examples/leaflet_core_library.html
@@ -4,7 +4,7 @@
     <title>Leaflet example | CartoDB.js</title>
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-    <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
+    <link rel="shortcut icon" href="https://carto.com/favicon.ico" />
     <style>
       html, body, #map {
         height: 100%;
@@ -12,13 +12,13 @@
         margin: 0;
       }
     </style>
-    <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.css" />
   </head>
   <body>
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.3/leaflet.js"></script>
     <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
 
     <script>

--- a/examples/leaflet_core_library.html
+++ b/examples/leaflet_core_library.html
@@ -16,10 +16,10 @@
   </head>
   <body>
     <div id="map"></div>
-    
+
     <!-- include cartodb.js library -->
     <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
 
     <script>
       function main() {
@@ -46,7 +46,7 @@
          L.tileLayer(tileTemplate.tiles[0], {
            attribution: 'Natural Earth data, map by CartoDB'
          }).addTo(map);
-        
+
         })
 
       }

--- a/examples/leaflet_hover_features.html
+++ b/examples/leaflet_hover_features.html
@@ -12,13 +12,13 @@
         margin: 0;
       }
     </style>
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
-    
+
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       function main() {

--- a/examples/leaflet_multilayer.html
+++ b/examples/leaflet_multilayer.html
@@ -13,19 +13,19 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
       function main() {
 
         // create leaflet map
-        var map = L.map('map', { 
+        var map = L.map('map', {
           zoomControl: false,
           center: [43, 0],
           zoom: 3
@@ -83,7 +83,7 @@
       }
 
       // you could use $(window).load(main);
-      window.onload = main; 
+      window.onload = main;
 
     </script>
 

--- a/examples/leaflet_raster.html
+++ b/examples/leaflet_raster.html
@@ -13,19 +13,19 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
       function main() {
 
         // create leaflet map
-        var map = L.map('map', { 
+        var map = L.map('map', {
           zoomControl: false,
           center: [43, 0],
           zoom: 3
@@ -47,7 +47,7 @@
       }
 
       // you could use $(window).load(main);
-      window.onload = main; 
+      window.onload = main;
 
     </script>
 

--- a/examples/leaflet_sandwich.html
+++ b/examples/leaflet_sandwich.html
@@ -13,20 +13,20 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.13/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.13/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
 
       function main() {
 
         // create leaflet map
-        var map = L.map('map', { 
+        var map = L.map('map', {
           zoomControl: false,
           center: [43, 0],
           zoom: 3
@@ -71,7 +71,7 @@
       }
 
       // you could use $(window).load(main);
-      window.onload = main; 
+      window.onload = main;
 
     </script>
 

--- a/examples/leaflet_sandwich.html
+++ b/examples/leaflet_sandwich.html
@@ -52,7 +52,7 @@
         .done(function(layer) {
           setTimeout(function() {
             layer.getSubLayer(0).setURLTemplate(
-               'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'
+               'https://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'
             )
           }, 4000);
 

--- a/examples/leaflet_vector.html
+++ b/examples/leaflet_vector.html
@@ -21,12 +21,12 @@
 
     <!-- include cartodb.js library -->
     <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
     <script>
 
       function main() {
 
-        var map = L.map('map', { 
+        var map = L.map('map', {
           zoomControl: false,
           center: [43, 0],
           zoom: 3

--- a/examples/leaflet_vector_hover.html
+++ b/examples/leaflet_vector_hover.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
     <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
-    
+
     <style>
       html, body, #map {
         height: 100%;
@@ -16,18 +16,18 @@
 
     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
 
-  </head>    
+  </head>
   <body>
     <div id="map"></div>
-    
+
     <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
 
     <script>
 
       function main() {
 
-        var map = L.map('map', { 
+        var map = L.map('map', {
           zoomControl: false,
           center: [43, 0],
           zoom: 3
@@ -40,7 +40,7 @@
         }).addTo(map);
 
         // create the layer and add to the map, then will be filled with data
-        var countriesLayer = L.geoJson(null, { 
+        var countriesLayer = L.geoJson(null, {
           style: {
             color: "#ff0000",
             fillColor: "#ff0000",

--- a/examples/leaflet_vector_query_distance.html
+++ b/examples/leaflet_vector_query_distance.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
     <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
-    
+
     <style>
       html, body, #map {
         height: 100%;
@@ -15,20 +15,20 @@
     </style>
 
     <link rel="stylesheet" href="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.css" />
-  </head>  
+  </head>
   <body>
     <div id="map"></div>
 
     <script src="http://cdn.leafletjs.com/leaflet-0.7.3/leaflet.js"></script>
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
 
     <script>
 
       function main() {
 
-        var map = L.map('map', { 
+        var map = L.map('map', {
           zoomControl: false,
-          center: [40.78151171, -73.94959818,0], 
+          center: [40.78151171, -73.94959818,0],
           zoom: 13
         })
 

--- a/examples/legends/custom.html
+++ b/examples/legends/custom.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <title>Legends | CartoDB.js</title>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" /> 
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
       window.onload = function() {
@@ -37,7 +37,7 @@
 
           };
 
-          cartodb.createVis('map', map_viz_url, { 
+          cartodb.createVis('map', map_viz_url, {
             legends: false,
             zoom: 3,
             no_cdn: true

--- a/examples/legends/index.html
+++ b/examples/legends/index.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <title>Legends | CartoDB.js</title>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" /> 
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
       currentLegend = null;
@@ -32,7 +32,7 @@
 
           currentLegend = stackedLegend;
 
-        } else { 
+        } else {
 
           $(".legend-selector a.selected").removeClass("selected");
           $link.addClass("selected");

--- a/examples/legends/stacked.html
+++ b/examples/legends/stacked.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <title>Legends | CartoDB.js</title>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" /> 
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
       window.onload = function() {
@@ -73,22 +73,22 @@
             //var legendsDataArray = [ customLegendData, densityLegendData ];
             var legendsArray = [ choroplethLegend, intensityLegend, customLegend, densityLegend, bubbleLegend ];
 
-            var legendsDataArray = [ 
+            var legendsDataArray = [
               {
               type: "choropleth",
               title: "Choropleth Legend",
               left: "10",
-              right: "20", 
+              right: "20",
               colors: [ "#58A062", "#F07971", "#54BFDE", "#9BC562", "#FABB5C" ]
             },
               {
               type: "choropleth",
               title: "Choropleth Legend",
               left: "10",
-              right: "20", 
+              right: "20",
               colors: [ "#58A062", "#F07971", "#54BFDE", "#9BC562", "#FABB5C" ]
             }
-            
+
             ];
 
             var stackedLegend = new cdb.geo.ui.Legend.Stacked({
@@ -102,7 +102,7 @@
 
           };
 
-          cartodb.createVis('map', map_viz_url, { 
+          cartodb.createVis('map', map_viz_url, {
             legends: false,
             zoom: 3,
             no_cdn: true

--- a/examples/map_dragging_disabled.html
+++ b/examples/map_dragging_disabled.html
@@ -13,13 +13,13 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       function main() {

--- a/examples/mobile.html
+++ b/examples/mobile.html
@@ -12,17 +12,17 @@
         margin: 0;
       }
     </style>
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       function main() {
-        var map = new L.Map('map', { 
+        var map = new L.Map('map', {
           zoomControl: false,
           center: [43, 0],
           zoom: 3

--- a/examples/modestmaps.html
+++ b/examples/modestmaps.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
     <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
-    
+
     <style>
       html, body, #map {
         height: 100%;
@@ -15,15 +15,15 @@
     </style>
 
   </head>
-    
+
   <body>
     <div id="map"></div>
-    
+
     <script src="http://modestmaps.com/modestmaps.min.js"></script>
     <!-- include cartodb.core.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
     <script>
-      
+
       // create the map
       var template = 'http://c.tiles.mapbox.com/v3/examples.map-szwdot65/{Z}/{X}/{Y}.png';
       var provider = new MM.TemplatedLayer(template);
@@ -49,7 +49,7 @@
         var cartodbLayer = new MM.TemplatedLayer(template, '0123');
         map.insertLayerAt(1, cartodbLayer);
       });
-      
+
 
     </script>
 

--- a/examples/new-infowindow.html
+++ b/examples/new-infowindow.html
@@ -5,9 +5,9 @@
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
     <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
-    
+
     <style>html, body, #map { height: 100%; padding: 0; margin: 0 }</style>
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
@@ -36,20 +36,20 @@
     </script>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
-    
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+
     <script type="text/javascript">
       var layer;
 
       function main() {
 
-        var map = L.map('map', { 
+        var map = L.map('map', {
           zoomControl: false,
           center: [43, -3],
           zoom: 3
         });
 
-        // add a nice baselayer from Stamen 
+        // add a nice baselayer from Stamen
         L.tileLayer('http://a.tiles.mapbox.com/v3/examples.map-20v6611k/{z}/{x}/{y}.png', {
           attribution: 'MapBox'
         }).addTo(map);
@@ -68,7 +68,7 @@
       }
 
       window.onload = main;
-      
+
     </script>
   </body>
 </html>

--- a/examples/odyssey_test.html
+++ b/examples/odyssey_test.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>

--- a/examples/openlayers.html
+++ b/examples/openlayers.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
     <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
-    
+
     <style>
       html, body, #map {
         height: 100%;
@@ -20,7 +20,7 @@
     <div id="map"></div>
 
     <!-- include cartodb.core.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
     <script src="vendor/OpenLayers.js"></script>
     <script type="text/javascript">
        var map, layer;

--- a/examples/openlayers.html
+++ b/examples/openlayers.html
@@ -4,7 +4,7 @@
     <title>OpenLayers example | CartoDB.js</title>
     <meta name="viewport" content="initial-scale=1.0, user-scalable=no" />
     <meta http-equiv="content-type" content="text/html; charset=UTF-8"/>
-    <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
+    <link rel="shortcut icon" href="https://carto.com/favicon.ico" />
 
     <style>
       html, body, #map {

--- a/examples/openlayers3.html
+++ b/examples/openlayers3.html
@@ -20,7 +20,7 @@
     <div id="map"></div>
 
     <!-- include cartodb.core.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.core.js"></script>
     <script src="http://openlayers.org/en/v3.12.1/build/ol.js"></script>
     <script type="text/javascript">
        var map, layer;

--- a/examples/openlayers3.html
+++ b/examples/openlayers3.html
@@ -55,7 +55,7 @@
                       '© <a href="http://www.openstreetmap.org/copyright">' +
                       'OpenStreetMap contributors</a>'
                    })],
-                  url:'http://{1-4}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png'
+                  url:'https://{1-4}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}.png'
                 })
               }),
               new ol.layer.Tile({

--- a/examples/plain-color.html
+++ b/examples/plain-color.html
@@ -28,7 +28,7 @@
       .map img { display: none; }
     </style>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
       var layer_definition = {

--- a/examples/search_with_pin.html
+++ b/examples/search_with_pin.html
@@ -13,12 +13,12 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       window.onload = function() {

--- a/examples/single-image.html
+++ b/examples/single-image.html
@@ -26,7 +26,7 @@
         background-color: #f8f8f8;
       }
     </style>
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
   </head>
   <body>
     <div id="content">

--- a/examples/slider.html
+++ b/examples/slider.html
@@ -7,8 +7,8 @@
     <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
 
     <!-- CartoDB library -->
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/themes/css/cartodb.css" />
-    <script type="text/javascript" src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/themes/css/cartodb.css" />
+    <script type="text/javascript" src="https://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <!-- JQuery library -->
     <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
@@ -64,7 +64,7 @@
 
         return map;
       }
-      
+
 
       function main() {
         var before = _generate_map("before"),

--- a/examples/slider/slider.html
+++ b/examples/slider/slider.html
@@ -7,8 +7,8 @@
     <link rel="shortcut icon" href="http://cartodb.com/assets/favicon.ico" />
 
     <!-- CartoDB library -->
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/themes/css/cartodb.css" />
-    <script type="text/javascript" src="http://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.12/cartodb.js"></script>
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/themes/css/cartodb.css" />
+    <script type="text/javascript" src="https://libs.cartocdn.com.s3.amazonaws.com/cartodb.js/v3/3.12/cartodb.js"></script>
 
     <!-- JQuery library -->
     <script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/2.1.1/jquery.min.js"></script>
@@ -64,7 +64,7 @@
 
         return map;
       }
-      
+
 
       function main() {
         var before = _generate_map("before"),

--- a/examples/stacked.html
+++ b/examples/stacked.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <title>Legends | CartoDB.js</title>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" /> 
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
       window.onload = function() {
@@ -73,22 +73,22 @@
             //var legendsDataArray = [ customLegendData, densityLegendData ];
             var legendsArray = [ choroplethLegend, intensityLegend, customLegend, densityLegend, bubbleLegend ];
 
-            var legendsDataArray = [ 
+            var legendsDataArray = [
               {
               type: "choropleth",
               title: "Choropleth Legend",
               left: "10",
-              right: "20", 
+              right: "20",
               colors: [ "#58A062", "#F07971", "#54BFDE", "#9BC562", "#FABB5C" ]
             },
               {
               type: "choropleth",
               title: "Choropleth Legend",
               left: "10",
-              right: "20", 
+              right: "20",
               colors: [ "#58A062", "#F07971", "#54BFDE", "#9BC562", "#FABB5C" ]
             }
-            
+
             ];
 
             var stackedLegend = new cdb.geo.ui.Legend.Stacked({
@@ -102,7 +102,7 @@
 
           };
 
-          cartodb.createVis('map', map_viz_url, { 
+          cartodb.createVis('map', map_viz_url, {
             legends: false,
             zoom: 3,
             no_cdn: true

--- a/examples/sublayer.html
+++ b/examples/sublayer.html
@@ -12,17 +12,17 @@
         margin: 0;
       }
     </style>
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       function main() {
-        var map = new L.Map('map', { 
+        var map = new L.Map('map', {
           zoomControl: false,
           center: [43, 0],
           zoom: 3

--- a/examples/time_slider.html
+++ b/examples/time_slider.html
@@ -27,7 +27,7 @@
       }
     </style>
     <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
-    <link rel="stylesheet" href="http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" />
+    <link rel="stylesheet" href="https://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" />
   </head>
   <body>
     <div id="map"></div>
@@ -37,7 +37,7 @@
 
     <!-- include cartodb.js library -->
     <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
-    <script src="http://code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
+    <script src="http://code.jquery.com/ui/1.10.3/jquery-ui.min.js"></script>
 
     <script>
 

--- a/examples/time_slider.html
+++ b/examples/time_slider.html
@@ -26,7 +26,7 @@
         left: 40px;
       }
     </style>
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
     <link rel="stylesheet" href="http://code.jquery.com/ui/1.10.3/themes/smoothness/jquery-ui.css" />
   </head>
   <body>
@@ -34,9 +34,9 @@
     <div id="slider"></div>
     <div id="legend"></div>
 
-    
+
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script src="http://code.jquery.com/ui/1.10.3/jquery-ui.js"></script>
 
     <script>

--- a/examples/torque.html
+++ b/examples/torque.html
@@ -31,7 +31,7 @@
     <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
-      cartodb.Image("http://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json").size(500, 500).getUrl(function(error, url) {
+      cartodb.Image("https://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json").size(500, 500).getUrl(function(error, url) {
 
         var img = new Image();
 

--- a/examples/torque.html
+++ b/examples/torque.html
@@ -28,7 +28,7 @@
       .map img { display: none; }
     </style>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
       cartodb.Image("http://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json").size(500, 500).getUrl(function(error, url) {

--- a/examples/torque_step.html
+++ b/examples/torque_step.html
@@ -31,7 +31,7 @@
     <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
-      cartodb.Image("http://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json", { step: 100 }).size(500, 500).getUrl(function(error, url) {
+      cartodb.Image("https://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json", { step: 100 }).size(500, 500).getUrl(function(error, url) {
 
         var img = new Image();
 

--- a/examples/torque_step.html
+++ b/examples/torque_step.html
@@ -28,7 +28,7 @@
       .map img { display: none; }
     </style>
 
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
     <script>
 
       cartodb.Image("http://documentation.cartodb.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json", { step: 100 }).size(500, 500).getUrl(function(error, url) {

--- a/examples/tutorial-google-driving.html
+++ b/examples/tutorial-google-driving.html
@@ -52,7 +52,7 @@
         var exploratorium = new google.maps.LatLng(37.801434, -122.397561);
 
         // Our CartoDB visualization
-        var vizjson_url = "http://documentation.cartodb.com/api/v2/viz/4a885510-d6fb-11e4-aedb-0e4fddd5de28/viz.json";
+        var vizjson_url = "https://documentation.cartodb.com/api/v2/viz/4a885510-d6fb-11e4-aedb-0e4fddd5de28/viz.json";
 
         cartodb.createLayer(map, vizjson_url)
         .addTo(map)

--- a/examples/tutorial-google-driving.html
+++ b/examples/tutorial-google-driving.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js"></script>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
 
@@ -35,7 +35,7 @@
 
         var myOptions = {
           zoom: 13,
-          center: myLatlng, 
+          center: myLatlng,
           disableDefaultUI: true,
           mapTypeId: google.maps.MapTypeId.ROADMAP
         }
@@ -57,9 +57,9 @@
         cartodb.createLayer(map, vizjson_url)
         .addTo(map)
         .done(function(layers) {
-          
+
             var subLayer = layers.getSubLayer(0);
-            
+
             subLayer.setInteraction(true); // Interaction for that layer must be enabled
             cdb.vis.Vis.addCursorInteraction(map, subLayer); // undo with removeCursorInteraction
 

--- a/examples/tutorial-google-heatmap-2.html
+++ b/examples/tutorial-google-heatmap-2.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
 
   </head>
   <body>
@@ -23,7 +23,7 @@
     <script src="https://maps.googleapis.com/maps/api/js?v=3.30&libraries=visualization"></script>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       var map, pointarray, heatmap;
@@ -35,7 +35,7 @@
 
         var myOptions = {
           zoom: 14,
-          center: myLatlng, 
+          center: myLatlng,
           disableDefaultUI: true,
           mapTypeId: google.maps.MapTypeId.SATELLITE
         }
@@ -48,7 +48,7 @@
         sql.execute("SELECT cartodb_id, the_geom FROM cleveland_spring_points_281_29").done(function(data) {
 
           data = data.features.map(function(r) {
-              return new google.maps.LatLng(r.geometry.coordinates[1], r.geometry.coordinates[0]) 
+              return new google.maps.LatLng(r.geometry.coordinates[1], r.geometry.coordinates[0])
             });
 
           var pointArray = new google.maps.MVCArray(data);

--- a/examples/tutorial-google-heatmap.html
+++ b/examples/tutorial-google-heatmap.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
 
   </head>
   <body>
@@ -28,7 +28,7 @@
 </script>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       var map, pointarray, heatmap;
@@ -39,7 +39,7 @@
 
         var myOptions = {
           zoom: 14,
-          center: myLatlng, 
+          center: myLatlng,
           disableDefaultUI: true,
           mapTypeId: google.maps.MapTypeId.SATELLITE
         }
@@ -52,7 +52,7 @@
         sql.execute("SELECT cartodb_id, the_geom FROM cleveland_spring_points_281_29").done(function(data) {
 
           data = data.features.map(function(r) {
-              return new google.maps.LatLng(r.geometry.coordinates[1], r.geometry.coordinates[0]) 
+              return new google.maps.LatLng(r.geometry.coordinates[1], r.geometry.coordinates[0])
             });
 
           var pointArray = new google.maps.MVCArray(data);

--- a/examples/tutorials/tutorial-google-driving.html
+++ b/examples/tutorials/tutorial-google-driving.html
@@ -52,7 +52,7 @@
         var exploratorium = new google.maps.LatLng(37.801434, -122.397561);
 
         // Our CartoDB visualization
-        var vizjson_url = "http://documentation.cartodb.com/api/v2/viz/4a885510-d6fb-11e4-aedb-0e4fddd5de28/viz.json";
+        var vizjson_url = "https://documentation.cartodb.com/api/v2/viz/4a885510-d6fb-11e4-aedb-0e4fddd5de28/viz.json";
 
         cartodb.createLayer(map, vizjson_url)
         .addTo(map)

--- a/examples/tutorials/tutorial-google-driving.html
+++ b/examples/tutorials/tutorial-google-driving.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
   </head>
   <body>
     <div id="map"></div>
@@ -22,7 +22,7 @@
     <script type="text/javascript" src="https://maps.googleapis.com/maps/api/js"></script>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
 
@@ -35,7 +35,7 @@
 
         var myOptions = {
           zoom: 13,
-          center: myLatlng, 
+          center: myLatlng,
           disableDefaultUI: true,
           mapTypeId: google.maps.MapTypeId.ROADMAP
         }
@@ -57,9 +57,9 @@
         cartodb.createLayer(map, vizjson_url)
         .addTo(map)
         .done(function(layers) {
-          
+
             var subLayer = layers.getSubLayer(0);
-            
+
             subLayer.setInteraction(true); // Interaction for that layer must be enabled
             cdb.vis.Vis.addCursorInteraction(map, subLayer); // undo with removeCursorInteraction
 

--- a/examples/tutorials/tutorial-google-heatmap-2.html
+++ b/examples/tutorials/tutorial-google-heatmap-2.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
 
   </head>
   <body>
@@ -23,7 +23,7 @@
     <script src="https://maps.googleapis.com/maps/api/js?v=3.30&libraries=visualization"></script>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       var map, pointarray, heatmap;
@@ -35,7 +35,7 @@
 
         var myOptions = {
           zoom: 14,
-          center: myLatlng, 
+          center: myLatlng,
           disableDefaultUI: true,
           mapTypeId: google.maps.MapTypeId.SATELLITE
         }
@@ -48,7 +48,7 @@
         sql.execute("SELECT cartodb_id, the_geom FROM cleveland_spring_points_281_29").done(function(data) {
 
           data = data.features.map(function(r) {
-              return new google.maps.LatLng(r.geometry.coordinates[1], r.geometry.coordinates[0]) 
+              return new google.maps.LatLng(r.geometry.coordinates[1], r.geometry.coordinates[0])
             });
 
           var pointArray = new google.maps.MVCArray(data);

--- a/examples/tutorials/tutorial-google-heatmap-2.html
+++ b/examples/tutorials/tutorial-google-heatmap-2.html
@@ -20,7 +20,7 @@
     <div id="map"></div>
 
     <!-- include google maps library + visualization-->
-    <script src="https://maps.googleapis.com/maps/api/js?v=3.30&libraries=visualization"></script>
+    <script src="https://maps.googleapis.com/maps/api/js?v=3.33&libraries=visualization"></script>
 
     <!-- include cartodb.js library -->
     <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>

--- a/examples/tutorials/tutorial-google-heatmap.html
+++ b/examples/tutorials/tutorial-google-heatmap.html
@@ -13,7 +13,7 @@
       }
     </style>
 
-    <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
+    <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.15/themes/css/cartodb.css" />
 
   </head>
   <body>
@@ -28,7 +28,7 @@
 </script>
 
     <!-- include cartodb.js library -->
-    <script src="http://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
+    <script src="https://libs.cartocdn.com/cartodb.js/v3/3.15/cartodb.js"></script>
 
     <script>
       var map, pointarray, heatmap;
@@ -39,7 +39,7 @@
 
         var myOptions = {
           zoom: 14,
-          center: myLatlng, 
+          center: myLatlng,
           disableDefaultUI: true,
           mapTypeId: google.maps.MapTypeId.SATELLITE
         }
@@ -52,7 +52,7 @@
         sql.execute("SELECT cartodb_id, the_geom FROM cleveland_spring_points_281_29").done(function(data) {
 
           data = data.features.map(function(r) {
-              return new google.maps.LatLng(r.geometry.coordinates[1], r.geometry.coordinates[0]) 
+              return new google.maps.LatLng(r.geometry.coordinates[1], r.geometry.coordinates[0])
             });
 
           var pointArray = new google.maps.MVCArray(data);

--- a/examples/tutorials/tutorial-query_by_distance-template.html
+++ b/examples/tutorials/tutorial-query_by_distance-template.html
@@ -1,12 +1,12 @@
 <html>
 <head>
-  <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
-  <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
+  <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
+  <script src="https://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
   <style>
     html, body {width:100%; height:100%; padding: 0; margin: 0;}
     #map { width: 100%; height:100%; background: black;}
     #menu { position: absolute; top: 5px; right: 10px; width: 400px; height:60px; background: transparent; z-index:10;}
-    #menu a { 
+    #menu a {
       margin: 15px 10px 0 0;
       float: right;
       vertical-align: baseline;
@@ -23,7 +23,7 @@
       cursor: pointer;
     }
     #menu a.selected,
-    #menu a:hover { 
+    #menu a:hover {
       color: #F84F40;
     }
   </style>
@@ -33,7 +33,7 @@
 
   function init(){
     // initiate leaflet map
-    map = new L.Map('map', { 
+    map = new L.Map('map', {
       center: [20,-20],
       zoom: 3
     })
@@ -48,10 +48,10 @@
 <body onload="init()">
   <div id='map'></div>
   <div id='menu'>
-    <a href="#500" id="500" value=500 class="button 500">500</a> 
-    <a href="#100" id="100" value=100 class="button 100">100</a> 
-    <a href="#50" id="50" value=50 class="button 50">50</a> 
-    <a href="#10" id="10" value=10 class="button 10 selected">10</a> 
+    <a href="#500" id="500" value=500 class="button 500">500</a>
+    <a href="#100" id="100" value=100 class="button 100">100</a>
+    <a href="#50" id="50" value=50 class="button 50">50</a>
+    <a href="#10" id="10" value=10 class="button 10 selected">10</a>
   </div>
 </body>
 </html>

--- a/examples/tutorials/tutorial-toggle_map_view-template.html
+++ b/examples/tutorials/tutorial-toggle_map_view-template.html
@@ -1,12 +1,12 @@
 <html>
 <head>
-  <link rel="stylesheet" href="http://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
-  <script src="http://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
+  <link rel="stylesheet" href="https://libs.cartocdn.com/cartodb.js/v3/3.12/themes/css/cartodb.css" />
+  <script src="https://libs.cartocdn.com/cartodb.js/v3/3.12/cartodb.js"></script>
   <style>
     html, body {width:100%; height:100%; padding: 0; margin: 0;}
     #map { width: 100%; height:100%; background: black;}
     #menu { position: absolute; top: 5px; right: 10px; width: 400px; height:60px; background: transparent; z-index:10;}
-    #menu a { 
+    #menu a {
       margin: 15px 10px 0 0;
       float: right;
       vertical-align: baseline;
@@ -23,7 +23,7 @@
       cursor: pointer;
     }
     #menu a.selected,
-    #menu a:hover { 
+    #menu a:hover {
       color: #F84F40;
     }
   </style>
@@ -32,7 +32,7 @@
   var map;
   function init(){
     // initiate leaflet map
-    map = new L.Map('map', { 
+    map = new L.Map('map', {
       center: [20,-20],
       zoom: 3
     })
@@ -47,8 +47,8 @@
 <body onload="init()">
   <div id='map'></div>
   <div id='menu'>
-    <a href="#megacities" id="megacities" class="button megacities">MEGACITIES</a> 
-    <a href="#capitals" id="capitals" class="button capitals">CAPITALS</a> 
+    <a href="#megacities" id="megacities" class="button megacities">MEGACITIES</a>
+    <a href="#capitals" id="capitals" class="button capitals">CAPITALS</a>
     <a href="#all" id="all" class="button all">ALL CITIES</a>
   </div>
 </body>

--- a/test/spec/core/image.spec.js
+++ b/test/spec/core/image.spec.js
@@ -32,12 +32,11 @@ describe("Image", function() {
   });
 
   it("should generate the URL for a torque layer", function(done) {
-
     var vizjson = "http://documentation.carto.com/api/v2/viz/3ec995a8-b6ae-11e4-849e-0e4fddd5de28/viz.json"
 
     var image = cartodb.Image(vizjson);
 
-    var regexp = new RegExp("http://a.ashbu.cartocdn.com/documentation/api/v1/map/static/bbox/(.*?)/-138\.6474609375,27\.761329874505233,-83\.408203125,51\.26191485308451/320/240\.pn");
+    var regexp = new RegExp("http://a.gusc.cartocdn.com/documentation/api/v1/map/static/bbox/(.*?)/-138\.6474609375,27\.761329874505233,-83\.408203125,51\.26191485308451/320/240\.pn");
 
     image.getUrl(function(err, url) {
       expect(image.options.layers.layers.length).toEqual(2);
@@ -168,8 +167,8 @@ describe("Image", function() {
     var image = cartodb.Image(vizjson);
 
     image.getUrl(function(err, url) {
-      expect(image.options.cdn_url.http).toEqual("ashbu.cartocdn.com");
-      expect(image.options.cdn_url.https).toEqual("cartocdn-ashbu.global.ssl.fastly.net");
+      expect(image.options.cdn_url.http).toEqual("gusc.cartocdn.com");
+      expect(image.options.cdn_url.https).toEqual("cartocdn-gusc.global.ssl.fastly.net");
       done();
     });
 
@@ -205,7 +204,7 @@ describe("Image", function() {
 
     var vizjson = "http://documentation.carto.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
 
-    var regexp = new RegExp("http://a.ashbu.cartocdn.com/documentation/api/v1/map/static/bbox/(.*?)/-31\.05,-155\.74,82\.58,261\.21/400/300\.png");
+    var regexp = new RegExp("http://a.gusc.cartocdn.com/documentation/api/v1/map/static/bbox/(.*?)/-31\.05,-155\.74,82\.58,261\.21/400/300\.png");
 
     cartodb.Image(vizjson).bbox([-31.05, -155.74, 82.58, 261.21]).size(400,300).getUrl(function(error, url) {
       expect(error).toEqual(null);
@@ -220,7 +219,7 @@ describe("Image", function() {
 
     var vizjson = "http://documentation.carto.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
 
-    var regexp = new RegExp("http://a.ashbu.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/52\.5897007687178/52\.734375/400/300\.png");
+    var regexp = new RegExp("http://a.gusc.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/52\.5897007687178/52\.734375/400/300\.png");
 
     cartodb.Image(vizjson, { override_bbox: true }).size(400,300).getUrl(function(error, url) {
       expect(error).toEqual(null);
@@ -235,7 +234,7 @@ describe("Image", function() {
 
     var vizjson = "http://documentation.carto.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
 
-    var regexp = new RegExp("http://a.ashbu.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/52\.5897007687178/52\.734375/400/300\.png");
+    var regexp = new RegExp("http://a.gusc.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/52\.5897007687178/52\.734375/400/300\.png");
 
     cartodb.Image(vizjson).bbox([]).size(400,300).getUrl(function(error, url) {
       expect(error).toEqual(null);
@@ -252,7 +251,7 @@ describe("Image", function() {
 
     var image = cartodb.Image(vizjson);
 
-    var regexp = new RegExp("http://a.ashbu.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/2/40/10/320/240\.png");
+    var regexp = new RegExp("http://a.gusc.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/2/40/10/320/240\.png");
 
     image.center([40,10]).getUrl(function(err, url) {
       expect(image.imageOptions.zoom).toEqual(2);
@@ -293,7 +292,7 @@ describe("Image", function() {
 
     var vizjson = "http://documentation.carto.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
 
-    var regexp = new RegExp("http://a.ashbu.cartocdn.com/documentation/api/v1/map/static/bbox/(.*?)320/240\.png");
+    var regexp = new RegExp("http://a.gusc.cartocdn.com/documentation/api/v1/map/static/bbox/(.*?)320/240\.png");
 
     cartodb.Image(vizjson).getUrl(function(error, url) {
       expect(error).toEqual(null);
@@ -308,7 +307,7 @@ describe("Image", function() {
 
     var vizjson = "http://documentation.carto.com/api/v2/viz/2b13c956-e7c1-11e2-806b-5404a6a683d5/viz.json"
 
-    var regexp = new RegExp("http://a.ashbu.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/7/40/10/400/300\.png");
+    var regexp = new RegExp("http://a.gusc.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/7/40/10/400/300\.png");
 
     cartodb.Image(vizjson).center([40, 10]).zoom(7).size(400, 300).getUrl(function(error, url) {
       expect(error).toEqual(null);
@@ -327,7 +326,7 @@ describe("Image", function() {
 
     cartodb.Image(vizjson).center([40, 10]).zoom(7).size(400, 300).into(img);
 
-    var regexp = new RegExp("http://a.ashbu.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/7/40/10/400/300\.png");
+    var regexp = new RegExp("http://a.gusc.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/7/40/10/400/300\.png");
 
     setTimeout(function() {
       expect($("#image").attr("src")).toMatch(regexp);
@@ -359,7 +358,7 @@ describe("Image", function() {
       }]
     };
 
-    var regexp = new RegExp("http://a.ashbu.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/2/0/0/250/250\.png");
+    var regexp = new RegExp("http://a.gusc.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/2/0/0/250/250\.png");
 
     cartodb.Image(layer_definition).size(250, 250).zoom(2).getUrl(function(error, url) {
       expect(url.match(regexp).length).toEqual(2);
@@ -419,7 +418,7 @@ describe("Image", function() {
       }]
     };
 
-    var regexp = new RegExp("http://a.ashbu.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/2/0/0/250/250\.png");
+    var regexp = new RegExp("http://a.gusc.cartocdn.com/documentation/api/v1/map/static/center/(.*?)/2/0/0/250/250\.png");
 
     cartodb.Image(layer_definition).size(250, 250).zoom(2).getUrl(function(error, url) {
       expect(url.match(regexp).length).toEqual(2);
@@ -435,7 +434,7 @@ describe("Image", function() {
 
     var image = cartodb.Image(vizjson).size(400, 300);
 
-    var regexp = new RegExp("https://cartocdn-ashbu.global.ssl.fastly.net/documentation/api/v1/map/static/bbox/(.*?)400/300\.png");
+    var regexp = new RegExp("https://cartocdn-gusc.global.ssl.fastly.net/documentation/api/v1/map/static/bbox/(.*?)400/300\.png");
 
     image.getUrl(function(err, url) {
       expect(url.match(regexp).length).toEqual(2);
@@ -451,7 +450,7 @@ describe("Image", function() {
 
     var image = cartodb.Image(vizjson).size(400, 300);
 
-    var regexp = new RegExp("http://a.ashbu.cartocdn.com/documentation/api/v1/map/static/bbox/(.*?)400/300\.png");
+    var regexp = new RegExp("http://a.gusc.cartocdn.com/documentation/api/v1/map/static/bbox/(.*?)400/300\.png");
 
     image.getUrl(function(err, url) {
       expect(url.match(regexp).length).toEqual(2);

--- a/test/spec/geo/gmaps_cartodb_layer/show.js
+++ b/test/spec/geo/gmaps_cartodb_layer/show.js
@@ -61,7 +61,6 @@ describe('Show functionality', function() {
   });
 
   it('toggle layer from hidden state should work', function(done) {
-
     setTimeout(function () {
       cdb_layer.show();
       visibility = cdb_layer.toggle();


### PR DESCRIPTION
This PR renames HTTP protocol from `http` to `https` in CARTO CDN scripts and stylesheets.

Coming from https://github.com/CartoDB/developers/issues/391.