### PR TITLE
Filters improvements

### DIFF
--- a/src/api/v4/filter/base-sql.js
+++ b/src/api/v4/filter/base-sql.js
@@ -53,7 +53,7 @@ class SQLBase extends Base {
    * @param {object} filters - The object containing all the new filters to apply.
    */
   setFilters (filters) {
-    if (!filters || !_.isObject(filters) || _.isEmpty(filters)) {
+    if (!filters || !_.isObject(filters)) {
       return;
     }
 
@@ -61,6 +61,13 @@ class SQLBase extends Base {
     this._filters = filters;
 
     this.trigger('change:filters', filters);
+  }
+
+  /**
+   * Remove all conditions from current filter
+   */
+  resetFilters () {
+    this.setFilters({});
   }
 
   $getSQL () {

--- a/src/api/v4/filter/category.js
+++ b/src/api/v4/filter/category.js
@@ -47,6 +47,7 @@ const ALLOWED_FILTERS = Object.freeze(Object.keys(CATEGORY_COMPARISON_OPERATORS)
  * airbnbDataset.addFilter(roomTypeFilter);
  *
  * @class Category
+ * @extends carto.filter.SQLBase
  * @memberof carto.filter
  * @api
  */
@@ -93,7 +94,7 @@ class Category extends SQLBase {
    */
 
   /**
-   * Set filter conditions, overriding all the previous ones.
+   * Remove all conditions from current filter
    *
    * @memberof Category
    * @method resetFilters

--- a/src/api/v4/filter/category.js
+++ b/src/api/v4/filter/category.js
@@ -20,9 +20,9 @@ const ALLOWED_FILTERS = Object.freeze(Object.keys(CATEGORY_COMPARISON_OPERATORS)
  *
  * @param {string} column - The column which the filter will be performed against
  * @param {object} filters - The filters you want to apply to the table rows
- * @param {string[]|string|object} filters.in - Return rows whose column value is included within the provided values
+ * @param {string[]|object} filters.in - Return rows whose column value is included within the provided values
  * @param {string} filters.in.query - Return rows whose column value is included within query results
- * @param {string[]|string|object} filters.notIn - Return rows whose column value is included within the provided values
+ * @param {string[]|object} filters.notIn - Return rows whose column value is included within the provided values
  * @param {string} filters.notIn.query - Return rows whose column value is not included within query results
  * @param {(string|number|Date)} filters.eq - Return rows whose column value is equal to the provided value
  * @param {(string|number|Date)} filters.notEq - Return rows whose column value is not equal to the provided value
@@ -89,6 +89,14 @@ class Category extends SQLBase {
    *
    * @memberof Category
    * @method setFilters
+   * @api
+   */
+
+  /**
+   * Set filter conditions, overriding all the previous ones.
+   *
+   * @memberof Category
+   * @method resetFilters
    * @api
    */
 }

--- a/src/api/v4/filter/category.js
+++ b/src/api/v4/filter/category.js
@@ -47,7 +47,7 @@ const ALLOWED_FILTERS = Object.freeze(Object.keys(CATEGORY_COMPARISON_OPERATORS)
  * airbnbDataset.addFilter(roomTypeFilter);
  *
  * @class Category
- * @extends carto.filter.SQLBase
+ * @extends carto.filter.Base
  * @memberof carto.filter
  * @api
  */

--- a/src/api/v4/filter/category.js
+++ b/src/api/v4/filter/category.js
@@ -20,8 +20,10 @@ const ALLOWED_FILTERS = Object.freeze(Object.keys(CATEGORY_COMPARISON_OPERATORS)
  *
  * @param {string} column - The column which the filter will be performed against
  * @param {object} filters - The filters you want to apply to the table rows
- * @param {string[]} filters.in - Return rows whose column value is included within the provided values
- * @param {string[]} filters.notIn - Return rows whose column value is included within the provided values
+ * @param {string[]|string|object} filters.in - Return rows whose column value is included within the provided values
+ * @param {string} filters.in.query - Return rows whose column value is included within query results
+ * @param {string[]|string|object} filters.notIn - Return rows whose column value is included within the provided values
+ * @param {string} filters.notIn.query - Return rows whose column value is not included within query results
  * @param {(string|number|Date)} filters.eq - Return rows whose column value is equal to the provided value
  * @param {(string|number|Date)} filters.notEq - Return rows whose column value is not equal to the provided value
  * @param {string} filters.like - Return rows whose column value is like the provided value
@@ -31,7 +33,17 @@ const ALLOWED_FILTERS = Object.freeze(Object.keys(CATEGORY_COMPARISON_OPERATORS)
  *
  * @example
  * // Create a filter by room type, showing only private rooms
- * const roomTypeFilter = new carto.filter.Category('room_type', { eq: 'Entire home/apt' });
+ * const roomTypeFilter = new carto.filter.Category('room_type', { eq: 'Private Room' });
+ * airbnbDataset.addFilter(roomTypeFilter);
+ *
+ * @example
+ * // Create a filter by room type, showing only private rooms and entire apartments
+ * const roomTypeFilter = new carto.filter.Category('room_type', { in: ['Private Room', 'Entire home/apt'] });
+ * airbnbDataset.addFilter(roomTypeFilter);
+ *
+ * @example
+ * // Create a filter by room type, showing results included in subquery
+ * const roomTypeFilter = new carto.filter.Category('room_type', { in: { query: 'SELECT distinct(type) FROM rooms' } });
  * airbnbDataset.addFilter(roomTypeFilter);
  *
  * @class Category

--- a/src/api/v4/filter/category.js
+++ b/src/api/v4/filter/category.js
@@ -20,9 +20,9 @@ const ALLOWED_FILTERS = Object.freeze(Object.keys(CATEGORY_COMPARISON_OPERATORS)
  *
  * @param {string} column - The column which the filter will be performed against
  * @param {object} filters - The filters you want to apply to the table rows
- * @param {string[]|object} filters.in - Return rows whose column value is included within the provided values
+ * @param {(string[]|object)} filters.in - Return rows whose column value is included within the provided values
  * @param {string} filters.in.query - Return rows whose column value is included within query results
- * @param {string[]|object} filters.notIn - Return rows whose column value is included within the provided values
+ * @param {(string[]|object)} filters.notIn - Return rows whose column value is included within the provided values
  * @param {string} filters.notIn.query - Return rows whose column value is not included within query results
  * @param {(string|number|Date)} filters.eq - Return rows whose column value is equal to the provided value
  * @param {(string|number|Date)} filters.notEq - Return rows whose column value is not equal to the provided value

--- a/src/api/v4/filter/category.js
+++ b/src/api/v4/filter/category.js
@@ -1,8 +1,8 @@
 const SQLBase = require('./base-sql');
 
 const CATEGORY_COMPARISON_OPERATORS = {
-  in: { parameters: [{ name: 'in', allowedTypes: ['Array', 'String'] }] },
-  notIn: { parameters: [{ name: 'notIn', allowedTypes: ['Array', 'String'] }] },
+  in: { parameters: [{ name: 'in', allowedTypes: ['Array', 'String', 'Object'] }] },
+  notIn: { parameters: [{ name: 'notIn', allowedTypes: ['Array', 'String', 'Object'] }] },
   eq: { parameters: [{ name: 'eq', allowedTypes: ['String', 'Number', 'Date'] }] },
   notEq: { parameters: [{ name: 'notEq', allowedTypes: ['String', 'Number', 'Date'] }] },
   like: { parameters: [{ name: 'like', allowedTypes: ['String'] }] },
@@ -52,8 +52,8 @@ class Category extends SQLBase {
 
   _getSQLTemplates () {
     return {
-      in: '<% if (value) { %><%= column %> IN (<%= value %>)<% } else { %>true = false<% } %>',
-      notIn: '<% if (value) { %><%= column %> NOT IN (<%= value %>)<% } %>',
+      in: '<% if (value) { %><%= column %> IN (<%= value.query || value %>)<% } else { %>true = false<% } %>',
+      notIn: '<% if (value) { %><%= column %> NOT IN (<%= value.query || value %>)<% } %>',
       eq: '<%= column %> = <%= value %>',
       notEq: '<%= column %> != <%= value %>',
       like: '<%= column %> LIKE <%= value %>',

--- a/src/api/v4/filter/filters-collection.js
+++ b/src/api/v4/filter/filters-collection.js
@@ -12,6 +12,8 @@ const DEFAULT_JOIN_OPERATOR = 'AND';
  * **This object should not be used directly.**
  *
  * @class FiltersCollection
+ * @abstract
+ * @extends carto.filter.Base
  * @memberof carto.filter
  * @api
  */

--- a/src/api/v4/filter/filters-collection.js
+++ b/src/api/v4/filter/filters-collection.js
@@ -90,14 +90,16 @@ class FiltersCollection extends Base {
   }
 
   $getSQL () {
-    const sql = this._filters.map(filter => filter.$getSQL())
-      .join(` ${this.JOIN_OPERATOR || DEFAULT_JOIN_OPERATOR} `);
+    const sqlFilters = this._filters.map(filter => filter.$getSQL())
+      .filter(sqlString => Boolean(sqlString));
 
-    if (this.count() > 1) {
-      return `(${sql})`;
+    const joinedFilters = sqlFilters.join(` ${this.JOIN_OPERATOR || DEFAULT_JOIN_OPERATOR} `);
+
+    if (sqlFilters.length > 1) {
+      return `(${joinedFilters})`;
     }
 
-    return sql;
+    return joinedFilters;
   }
 
   _triggerFilterChange (filters) {

--- a/src/api/v4/filter/range.js
+++ b/src/api/v4/filter/range.js
@@ -115,6 +115,14 @@ class Range extends SQLBase {
    * @method setFilters
    * @api
    */
+
+  /**
+   * Set filter conditions, overriding all the previous ones.
+   *
+   * @memberof Category
+   * @method resetFilters
+   * @api
+   */
 }
 
 module.exports = Range;

--- a/src/api/v4/filter/range.js
+++ b/src/api/v4/filter/range.js
@@ -69,6 +69,7 @@ const ALLOWED_FILTERS = Object.freeze(Object.keys(RANGE_COMPARISON_OPERATORS));
  * airbnbDataset.addFilter(priceFilter);
  *
  * @class Range
+ * @extends carto.filter.SQLBase
  * @memberof carto.filter
  * @api
  */
@@ -117,9 +118,9 @@ class Range extends SQLBase {
    */
 
   /**
-   * Set filter conditions, overriding all the previous ones.
+   * Remove all conditions from current filter
    *
-   * @memberof Category
+   * @memberof Range
    * @method resetFilters
    * @api
    */

--- a/src/api/v4/filter/range.js
+++ b/src/api/v4/filter/range.js
@@ -69,7 +69,7 @@ const ALLOWED_FILTERS = Object.freeze(Object.keys(RANGE_COMPARISON_OPERATORS));
  * airbnbDataset.addFilter(priceFilter);
  *
  * @class Range
- * @extends carto.filter.SQLBase
+ * @extends carto.filter.Base
  * @memberof carto.filter
  * @api
  */

--- a/test/spec/api/v4/filter/base-sql.spec.js
+++ b/test/spec/api/v4/filter/base-sql.spec.js
@@ -122,6 +122,19 @@ describe('api/v4/filter/base-sql', function () {
     });
   });
 
+  describe('.resetFilters', function () {
+    it('should reset applied filters', function () {
+      const sqlFilter = new SQLBase(column);
+      sqlFilter.ALLOWED_FILTERS = ['in'];
+      sqlFilter.PARAMETER_SPECIFICATION = { in: PARAMETER_SPECIFICATION.in };
+      sqlFilter.set('in', ['test_filter']);
+
+      sqlFilter.resetFilters();
+
+      expect(sqlFilter._filters).toEqual({});
+    });
+  });
+
   describe('.$getSQL', function () {
     it('should return SQL string containing all the filters joined by AND clause', function () {
       const sqlFilter = new SQLBase(column);

--- a/test/spec/api/v4/filter/category.spec.js
+++ b/test/spec/api/v4/filter/category.spec.js
@@ -15,9 +15,19 @@ describe('api/v4/filter/category', function () {
       expect(categoryFilter.$getSQL()).toBe("fake_column IN ('Category 1')");
     });
 
+    it('IN with subquery', function () {
+      const categoryFilter = new carto.filter.Category('fake_column', { in: { query: 'SELECT name FROM neighbourhoods' } });
+      expect(categoryFilter.$getSQL()).toBe('fake_column IN (SELECT name FROM neighbourhoods)');
+    });
+
     it('NOT IN', function () {
       const categoryFilter = new carto.filter.Category('fake_column', { notIn: ['Category 1'] });
       expect(categoryFilter.$getSQL()).toBe("fake_column NOT IN ('Category 1')");
+    });
+
+    it('NOT IN with subquery', function () {
+      const categoryFilter = new carto.filter.Category('fake_column', { notIn: { query: 'SELECT name FROM neighbourhoods' } });
+      expect(categoryFilter.$getSQL()).toBe('fake_column NOT IN (SELECT name FROM neighbourhoods)');
     });
 
     it('EQ', function () {

--- a/test/spec/api/v4/filter/filters-collection.spec.js
+++ b/test/spec/api/v4/filter/filters-collection.spec.js
@@ -142,6 +142,17 @@ describe('api/v4/filter/filters-collection', function () {
     it('should build the SQL string and join filters', function () {
       expect(filtersCollection.$getSQL()).toEqual("(fake_column < 1 AND fake_column IN ('category'))");
     });
+
+    it('should not take empty filters into account', function () {
+      let customRangeFilter = new carto.filter.Range(column, { lt: 1 });
+      let emptyFilter = new carto.filter.Category(column, {});
+
+      filtersCollection = new FiltersCollection();
+      filtersCollection.addFilter(customRangeFilter);
+      filtersCollection.addFilter(emptyFilter);
+
+      expect(filtersCollection.$getSQL()).toEqual('fake_column < 1');
+    });
   });
 
   describe('._triggerFilterChange', function () {


### PR DESCRIPTION
This PR fixes a bug and introduces several improvements in filters described in https://github.com/CartoDB/carto.js/issues/2186.

### Allow empty filters combination
There were a problem when combining several filters, when having one of them empty. So, now the problem is gone. You can:

```js
const roomTypeFilter = new carto.filter.Category('room_type', { in: getSelectedRoomTypes() });
const emptyFilter = new carto.filter.Category('price', { });

const source = new carto.source.SQL('SELECT * FROM table');
source.addFilters([ roomTypeFilter, emptyFilter ]);
```

### Reset filters conditions
Filters now have `.resetFilters()` method to remove all filter conditions and leave it empty.
```js
const roomTypeFilter = new carto.filter.Category('room_type', { in: getSelectedRoomTypes() });
roomTypeFilter.resetFilters();
```

### Subqueries for IN and NOT IN filters in Category filter
From now on, we're going to allow subqueries as a parameter for IN and NOT IN conditions. You only need to set `query` parameter in the filter value, like this:
```js
const roomTypeFilter = new carto.filter.Category('room_type', { in: { query: 'SELECT distinct(name) FROM room_types'} });
```