### PR TITLE
Allow subqueries parameter in Range filters and more Category Filters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+## 4.1.5 - 2018-09-05
+### Added
+- Source Filters: allow subqueries in `eq`, `notEq` in Category filter, and `lt`, `lte`, `gt`, `gte` in Range Filter.
+
 ## 4.1.4 - 2018-09-03
 ### Added
 - Source Filters: allow to filter category columns by subquery. [#2186](https://github.com/CartoDB/carto.js/issues/2186)

--- a/src/api/v4/filter/category.js
+++ b/src/api/v4/filter/category.js
@@ -3,8 +3,8 @@ const SQLBase = require('./base-sql');
 const CATEGORY_COMPARISON_OPERATORS = {
   in: { parameters: [{ name: 'in', allowedTypes: ['Array', 'String', 'Object'] }] },
   notIn: { parameters: [{ name: 'notIn', allowedTypes: ['Array', 'String', 'Object'] }] },
-  eq: { parameters: [{ name: 'eq', allowedTypes: ['String', 'Number', 'Date'] }] },
-  notEq: { parameters: [{ name: 'notEq', allowedTypes: ['String', 'Number', 'Date'] }] },
+  eq: { parameters: [{ name: 'eq', allowedTypes: ['String', 'Number', 'Date', 'Object'] }] },
+  notEq: { parameters: [{ name: 'notEq', allowedTypes: ['String', 'Number', 'Date', 'Object'] }] },
   like: { parameters: [{ name: 'like', allowedTypes: ['String'] }] },
   similarTo: { parameters: [{ name: 'similarTo', allowedTypes: ['String'] }] }
 };
@@ -24,8 +24,10 @@ const ALLOWED_FILTERS = Object.freeze(Object.keys(CATEGORY_COMPARISON_OPERATORS)
  * @param {string} filters.in.query - Return rows whose column value is included within query results
  * @param {(string[]|object)} filters.notIn - Return rows whose column value is included within the provided values
  * @param {string} filters.notIn.query - Return rows whose column value is not included within query results
- * @param {(string|number|Date)} filters.eq - Return rows whose column value is equal to the provided value
- * @param {(string|number|Date)} filters.notEq - Return rows whose column value is not equal to the provided value
+ * @param {(string|number|Date|object)} filters.eq - Return rows whose column value is equal to the provided value
+ * @param {string} filters.eq.query - Return rows whose column value is equal to the value returned by query
+ * @param {(string|number|Date|object)} filters.notEq - Return rows whose column value is not equal to the provided value
+ * @param {string} filters.notEq.query - Return rows whose column value is not equal to the value returned by query
  * @param {string} filters.like - Return rows whose column value is like the provided value
  * @param {string} filters.similarTo - Return rows whose column value is similar to the provided values
  * @param {object} [options]
@@ -67,8 +69,8 @@ class Category extends SQLBase {
     return {
       in: '<% if (value) { %><%= column %> IN (<%= value.query || value %>)<% } else { %>true = false<% } %>',
       notIn: '<% if (value) { %><%= column %> NOT IN (<%= value.query || value %>)<% } %>',
-      eq: '<%= column %> = <%= value %>',
-      notEq: '<%= column %> != <%= value %>',
+      eq: '<%= column %> = <%= value.query || value %>',
+      notEq: '<%= column %> != <%= value.query || value %>',
       like: '<%= column %> LIKE <%= value %>',
       similarTo: '<%= column %> SIMILAR TO <%= value %>'
     };

--- a/src/api/v4/filter/category.js
+++ b/src/api/v4/filter/category.js
@@ -69,8 +69,8 @@ class Category extends SQLBase {
     return {
       in: '<% if (value) { %><%= column %> IN (<%= value.query || value %>)<% } else { %>true = false<% } %>',
       notIn: '<% if (value) { %><%= column %> NOT IN (<%= value.query || value %>)<% } %>',
-      eq: '<%= column %> = <%= value.query || value %>',
-      notEq: '<%= column %> != <%= value.query || value %>',
+      eq: '<%= column %> = <%= value.query ? "(" + value.query + ")" : value %>',
+      notEq: '<%= column %> != <%= value.query ? "(" + value.query + ")" : value %>',
       like: '<%= column %> LIKE <%= value %>',
       similarTo: '<%= column %> SIMILAR TO <%= value %>'
     };

--- a/src/api/v4/filter/range.js
+++ b/src/api/v4/filter/range.js
@@ -91,10 +91,10 @@ class Range extends SQLBase {
 
   _getSQLTemplates () {
     return {
-      lt: '<%= column %> < <%= value.query || value %>',
-      lte: '<%= column %> <= <%= value.query || value %>',
-      gt: '<%= column %> > <%= value.query || value %>',
-      gte: '<%= column %> >= <%= value.query || value %>',
+      lt: '<%= column %> < <%= value.query ? "(" + value.query + ")" : value %>',
+      lte: '<%= column %> <= <%= value.query ? "(" + value.query + ")" : value %>',
+      gt: '<%= column %> > <%= value.query ? "(" + value.query + ")" : value %>',
+      gte: '<%= column %> >= <%= value.query ? "(" + value.query + ")" : value %>',
       between: '<%= column %> BETWEEN <%= value.min %> AND <%= value.max %>',
       notBetween: '<%= column %> NOT BETWEEN <%= value.min %> AND <%= value.max %>',
       betweenSymmetric: '<%= column %> BETWEEN SYMMETRIC <%= value.min %> AND <%= value.max %>',

--- a/src/api/v4/filter/range.js
+++ b/src/api/v4/filter/range.js
@@ -1,10 +1,10 @@
 const SQLBase = require('./base-sql');
 
 const RANGE_COMPARISON_OPERATORS = {
-  lt: { parameters: [{ name: 'lt', allowedTypes: ['Number', 'Date'] }] },
-  lte: { parameters: [{ name: 'lte', allowedTypes: ['Number', 'Date'] }] },
-  gt: { parameters: [{ name: 'gt', allowedTypes: ['Number', 'Date'] }] },
-  gte: { parameters: [{ name: 'gte', allowedTypes: ['Number', 'Date'] }] },
+  lt: { parameters: [{ name: 'lt', allowedTypes: ['Number', 'Date', 'Object'] }] },
+  lte: { parameters: [{ name: 'lte', allowedTypes: ['Number', 'Date', 'Object'] }] },
+  gt: { parameters: [{ name: 'gt', allowedTypes: ['Number', 'Date', 'Object'] }] },
+  gte: { parameters: [{ name: 'gte', allowedTypes: ['Number', 'Date', 'Object'] }] },
   between: {
     parameters: [
       { name: 'between.min', allowedTypes: ['Number', 'Date'] },
@@ -42,10 +42,14 @@ const ALLOWED_FILTERS = Object.freeze(Object.keys(RANGE_COMPARISON_OPERATORS));
  *
  * @param {string} column - The column to filter rows
  * @param {object} filters - The filters you want to apply to the column
- * @param {(number|Date)} filters.lt - Return rows whose column value is less than the provided value
- * @param {(number|Date)} filters.lte - Return rows whose column value is less than or equal to the provided value
- * @param {(number|Date)} filters.gt - Return rows whose column value is greater than to the provided value
- * @param {(number|Date)} filters.gte - Return rows whose column value is greater than or equal to the provided value
+ * @param {(number|Date|object)} filters.lt - Return rows whose column value is less than the provided value
+ * @param {string} filters.lt.query - Return rows whose column value is less than the value returned by query
+ * @param {(number|Date|object)} filters.lte - Return rows whose column value is less than or equal to the provided value
+ * @param {string} filters.lte.query - Return rows whose column value is less than or equal to the value returned by query
+ * @param {(number|Date|object)} filters.gt - Return rows whose column value is greater than the provided value
+ * @param {string} filters.gt.query - Return rows whose column value is greater than the value returned by query
+ * @param {(number|Date|object)} filters.gte - Return rows whose column value is greater than or equal to the provided value
+ * @param {string} filters.gte.query - Return rows whose column value is greater than or equal to the value returned by query
  * @param {(number|Date)} filters.between - Return rows whose column value is between the provided values
  * @param {(number|Date)} filters.between.min - Lower value of the comparison range
  * @param {(number|Date)} filters.between.max - Upper value of the comparison range
@@ -87,10 +91,10 @@ class Range extends SQLBase {
 
   _getSQLTemplates () {
     return {
-      lt: '<%= column %> < <%= value %>',
-      lte: '<%= column %> <= <%= value %>',
-      gt: '<%= column %> > <%= value %>',
-      gte: '<%= column %> >= <%= value %>',
+      lt: '<%= column %> < <%= value.query || value %>',
+      lte: '<%= column %> <= <%= value.query || value %>',
+      gt: '<%= column %> > <%= value.query || value %>',
+      gte: '<%= column %> >= <%= value.query || value %>',
       between: '<%= column %> BETWEEN <%= value.min %> AND <%= value.max %>',
       notBetween: '<%= column %> NOT BETWEEN <%= value.min %> AND <%= value.max %>',
       betweenSymmetric: '<%= column %> BETWEEN SYMMETRIC <%= value.min %> AND <%= value.max %>',

--- a/src/api/v4/filter/range.js
+++ b/src/api/v4/filter/range.js
@@ -72,6 +72,13 @@ const ALLOWED_FILTERS = Object.freeze(Object.keys(RANGE_COMPARISON_OPERATORS));
  * // Add filter to the existing source
  * airbnbDataset.addFilter(priceFilter);
  *
+ * @example
+ * // Create a filter by price, showing only listings greater than or equal to the average price
+ * const priceFilter = new carto.filter.Range('price', { gte: { query: 'SELECT avg(price) FROM listings' } });
+ *
+ * // Add filter to the existing source
+ * airbnbDataset.addFilter(priceFilter);
+ *
  * @class Range
  * @extends carto.filter.Base
  * @memberof carto.filter

--- a/test/spec/api/v4/filter/category.spec.js
+++ b/test/spec/api/v4/filter/category.spec.js
@@ -35,9 +35,19 @@ describe('api/v4/filter/category', function () {
       expect(categoryFilter.$getSQL()).toBe("fake_column = 'Category 1'");
     });
 
+    it('EQ with subquery', function () {
+      const categoryFilter = new carto.filter.Category('fake_column', { eq: { query: 'SELECT avg(price) FROM neighbourhoods' } });
+      expect(categoryFilter.$getSQL()).toBe('fake_column = (SELECT avg(price) FROM neighbourhoods)');
+    });
+
     it('NOT EQ', function () {
       const categoryFilter = new carto.filter.Category('fake_column', { notEq: 'Category 1' });
       expect(categoryFilter.$getSQL()).toBe("fake_column != 'Category 1'");
+    });
+
+    it('NOT EQ with subquery', function () {
+      const categoryFilter = new carto.filter.Category('fake_column', { notEq: { query: 'SELECT avg(price) FROM neighbourhoods' } });
+      expect(categoryFilter.$getSQL()).toBe('fake_column != (SELECT avg(price) FROM neighbourhoods)');
     });
 
     it('LIKE', function () {

--- a/test/spec/api/v4/filter/range.spec.js
+++ b/test/spec/api/v4/filter/range.spec.js
@@ -15,9 +15,19 @@ describe('api/v4/filter/range', function () {
       expect(categoryFilter.$getSQL()).toBe('fake_column < 10');
     });
 
+    it('LT with subquery', function () {
+      const categoryFilter = new carto.filter.Range('fake_column', { lt: { query: 'SELECT avg(price) FROM neighbourhoods' } });
+      expect(categoryFilter.$getSQL()).toBe('fake_column < (SELECT avg(price) FROM neighbourhoods)');
+    });
+
     it('LTE', function () {
       const categoryFilter = new carto.filter.Range('fake_column', { lte: 10 });
       expect(categoryFilter.$getSQL()).toBe('fake_column <= 10');
+    });
+
+    it('LTE with subquery', function () {
+      const categoryFilter = new carto.filter.Range('fake_column', { lte: { query: 'SELECT avg(price) FROM neighbourhoods' } });
+      expect(categoryFilter.$getSQL()).toBe('fake_column <= (SELECT avg(price) FROM neighbourhoods)');
     });
 
     it('GT', function () {
@@ -25,9 +35,19 @@ describe('api/v4/filter/range', function () {
       expect(categoryFilter.$getSQL()).toBe('fake_column > 10');
     });
 
+    it('GT with subquery', function () {
+      const categoryFilter = new carto.filter.Range('fake_column', { gt: { query: 'SELECT avg(price) FROM neighbourhoods' } });
+      expect(categoryFilter.$getSQL()).toBe('fake_column > (SELECT avg(price) FROM neighbourhoods)');
+    });
+
     it('GTE', function () {
       const categoryFilter = new carto.filter.Range('fake_column', { gte: 10 });
       expect(categoryFilter.$getSQL()).toBe('fake_column >= 10');
+    });
+
+    it('GTE with subquery', function () {
+      const categoryFilter = new carto.filter.Range('fake_column', { gte: { query: 'SELECT avg(price) FROM neighbourhoods' } });
+      expect(categoryFilter.$getSQL()).toBe('fake_column >= (SELECT avg(price) FROM neighbourhoods)');
     });
 
     it('BETWEEN', function () {


### PR DESCRIPTION
In a previous PR we introduced subquery parameter in NOT IN and IN category filters. I noticed that it can be passed in to another filters such as GT, GTE, LT, etc... So this PR add that features :)