### PR TITLE
Return default value only if value is undefined in get-object-value

### DIFF
--- a/src/util/get-object-value.js
+++ b/src/util/get-object-value.js
@@ -1,3 +1,5 @@
+const _ = require('underscore');
+
 /**
   * Gets the value at path of object. If the resolved value is undefined, the defaultValue is returned in its place.
   * @param {Object} object The object to query.
@@ -11,5 +13,5 @@ module.exports = function (object, path, defaultValue) {
     return (a || {})[b];
   }, object);
 
-  return value || defaultValue;
+  return _.isUndefined(value) ? defaultValue : value;
 };


### PR DESCRIPTION
Fix undefined behaviour in `get-object-value.js`.

I found a case that the function was returning `defaultValue` instead of `value` because it was 0. The return condition behaviour is different to what it was supposed to do.