### PR TITLE
Fix server url parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,10 +8,12 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
+### Fixed
+- Client: Fix `serverUrl` parameter: `{username}` replacement, validation and documentation.
 
 ## 4.1.6 - 2018-09-07
 ### Fixed
-- Source Filters: Fix return in get-object-value that was causing unintended behaviours in parameters validation.
+- Source Filters: Fix return in get-object-value that was causing unintended behaviors in parameters validation.
 
 ## 4.1.5 - 2018-09-05
 ### Added

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -13,6 +13,8 @@ function getValidationError (code) {
   return new CartoValidationError('client', code);
 }
 
+const DEFAULT_SERVER_URL = 'https://{username}.carto.com';
+
 /**
  * This is the entry point for a CARTO.js application.
  *
@@ -27,7 +29,7 @@ function getValidationError (code) {
  * @param {object} settings
  * @param {string} settings.apiKey - API key used to authenticate against CARTO
  * @param {string} settings.username - Name of the user
- * @param {string} [settings.serverUrl] - URL of the windshaft server. Only needed in custom installations. Pattern: `https:\\{username}.yourinstance.com` or `https://your.carto.instance/user/{username}`, depending on your environment.
+ * @param {string} [settings.serverUrl] - URL of the windshaft server. Only needed in custom installations. Pattern: `https:\\{username}.your.carto.instance` or `https://your.carto.instance/user/{username}`, depending on your environment.
  *
  * @example
  * var client = new carto.Client({
@@ -45,17 +47,17 @@ function getValidationError (code) {
  * @memberof carto
  * @api
  *
- * @fires error
  * @fires success
  */
 function Client (settings) {
+  settings.serverUrl = (settings.serverUrl || DEFAULT_SERVER_URL).replace(/{username}/, settings.username || '');
   _checkSettings(settings);
   this._layers = new Layers();
   this._dataviews = [];
   this._engine = new Engine({
     apiKey: settings.apiKey,
     username: settings.username,
-    serverUrl: settings.serverUrl || 'https://{user}.carto.com'.replace(/{user}/, settings.username),
+    serverUrl: settings.serverUrl,
     client: 'js-' + VERSION
   });
   this._bindEngine(this._engine);
@@ -507,7 +509,7 @@ function _checkUsername (username) {
 
 function _checkServerUrl (serverUrl, username) {
   var ipRegex = /https?:\/\/((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/;
-  var urlregex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&//=]*)/;
+  var urlregex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/;
   if (!serverUrl.match(urlregex) && !serverUrl.match(ipRegex)) {
     throw getValidationError('nonValidServerURL');
   }

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -29,7 +29,7 @@ const DEFAULT_SERVER_URL = 'https://{username}.carto.com';
  * @param {object} settings
  * @param {string} settings.apiKey - API key used to authenticate against CARTO
  * @param {string} settings.username - Name of the user
- * @param {string} [settings.serverUrl='https://{username}.carto.com'] - URL of the windshaft server. Only needed in custom installations. Pattern: `https://{username}.your.carto.instance` or `https://your.carto.instance/user/{username}` (for enterprise environments).
+ * @param {string} [settings.serverUrl='https://{username}.carto.com'] - URL of the windshaft server. Only needed in custom installations. Pattern: `http(s)://{username}.your.carto.instance` or `http(s)://your.carto.instance/user/{username}` (only for On-Premises environments).
  *
  * @example
  * var client = new carto.Client({
@@ -40,7 +40,7 @@ const DEFAULT_SERVER_URL = 'https://{username}.carto.com';
  * var client = new carto.Client({
  *   apiKey: 'YOUR_API_KEY_HERE',
  *   username: 'YOUR_USERNAME_HERE',
- *   serverUrl: 'https://{username}.your.carto.instance'
+ *   serverUrl: 'http://{username}.your.carto.instance'
  * });
  *
  * @constructor
@@ -508,9 +508,8 @@ function _checkUsername (username) {
 }
 
 function _checkServerUrl (serverUrl, username) {
-  var ipRegex = /https?:\/\/((25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)/;
-  var urlregex = /https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b([-a-zA-Z0-9@:%_\+.~#?&\/\/=]*)/;
-  if (!serverUrl.match(urlregex) && !serverUrl.match(ipRegex)) {
+  var urlregex = /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/;
+  if (!serverUrl.match(urlregex)) {
     throw getValidationError('nonValidServerURL');
   }
   if (serverUrl.indexOf(username) < 0) {

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -29,7 +29,7 @@ const DEFAULT_SERVER_URL = 'https://{username}.carto.com';
  * @param {object} settings
  * @param {string} settings.apiKey - API key used to authenticate against CARTO
  * @param {string} settings.username - Name of the user
- * @param {string} [settings.serverUrl] - URL of the windshaft server. Only needed in custom installations. Pattern: `https:\\{username}.your.carto.instance` or `https://your.carto.instance/user/{username}`, depending on your environment.
+ * @param {string} [settings.serverUrl='https://{username}.carto.com'] - URL of the windshaft server. Only needed in custom installations. Pattern: `https://{username}.your.carto.instance` or `https://your.carto.instance/user/{username}` (for enterprise environments).
  *
  * @example
  * var client = new carto.Client({
@@ -40,7 +40,7 @@ const DEFAULT_SERVER_URL = 'https://{username}.carto.com';
  * var client = new carto.Client({
  *   apiKey: 'YOUR_API_KEY_HERE',
  *   username: 'YOUR_USERNAME_HERE',
- *   serverUrl: 'https://YOUR.CARTO.INSTANCE/user/YOUR_USERNAME_HERE'
+ *   serverUrl: 'https://{username}.your.carto.instance'
  * });
  *
  * @constructor

--- a/src/api/v4/client.js
+++ b/src/api/v4/client.js
@@ -47,6 +47,7 @@ const DEFAULT_SERVER_URL = 'https://{username}.carto.com';
  * @memberof carto
  * @api
  *
+ * @fires error
  * @fires success
  */
 function Client (settings) {

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -63,16 +63,6 @@ describe('api/v4/client', function () {
       }).toThrow();
     });
 
-    it('should reject an invalid ip adress followed by /user/{username}', function () {
-      expect(function () {
-        client = new carto.Client({
-          apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
-          username: 'cartojs-test',
-          serverUrl: 'https://192.168.1/user/cartojs-test'
-        });
-      }).toThrow();
-    });
-
     it('should reject an invalid ip adress with no /user/{username}', function () {
       expect(function () {
         client = new carto.Client({

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -33,6 +33,16 @@ describe('api/v4/client', function () {
       expect(client._engine._windshaftSettings.urlTemplate).toEqual('https://cartojs-test.carto.com');
     });
 
+    it('should autogenerate the carto url when a template is given', function () {
+      client = new carto.Client({
+        apiKey: '84fdbd587e4a942510270a48e843b4c1baa11e18',
+        username: 'cartojs-test',
+        serverUrl: 'https://{username}.mycarto.com'
+      });
+
+      expect(client._engine._windshaftSettings.urlTemplate).toEqual('https://cartojs-test.mycarto.com');
+    });
+
     it('should accept a ipv4/user/{username} as a valid serverURL', function () {
       expect(function () {
         client = new carto.Client({


### PR DESCRIPTION
https://github.com/CartoDB/carto.js/issues/2198
---

- Fixed `{username}` pattern in `serverUrl` parameter (+test).
- Unify URL regex in `checkServerUrl` function.
- Fixed the documentation:
    - `http(s)://{username}.your.carto.instance` is the general pattern.
    - `http(s)://your.carto.instance/user/{username}`  is only for On-Premises environments.
- Update Changelog
