### PR TITLE
Move browserify-shim to dependencies from devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
   "dependencies": {
     "backbone": "1.2.3",
     "backbone-poller": "^1.1.3",
-    "browserify-shim": "3.8.12",
     "camshaft-reference": "0.34.0",
     "carto": "cartodb/carto#master",
     "@carto/zera": "1.0.7",
@@ -58,6 +57,7 @@
     "babel-preset-es2015": "~6.24.1",
     "babelify": "^7.3.0",
     "browserify": "13.0.0",
+    "browserify-shim": "3.8.12",
     "cartoassets": "CartoDB/CartoAssets#master",
     "eslint": "~4.8.0",
     "eslint-config-semistandard": "~11.0.0",

--- a/package.json
+++ b/package.json
@@ -102,8 +102,8 @@
     "time-grunt": "~0.3.1",
     "uglifyjs-webpack-plugin": "^1.1.2",
     "watchify": "3.4.0",
-    "webpack": "^4.12.1",
-    "webpack-cli": "^3.0.8"
+    "webpack": "4.12.1",
+    "webpack-cli": "^3.0.4"
   },
   "browserify": {
     "transform": [


### PR DESCRIPTION
While investigating an issue on Builder's shrinkwrap I encountered a problem with carto.js. By having browserify-shim as a dependency, if a project installs it, shrinkwrapping will fail unless you have browserify installed as well (it's a peer dependency of browserify-shim).

To verify this, create a new npm project (tested with npm 3), add carto.js as a dependency, and try having something like `update-internal-deps` in builder. Check it against this branch later and it should work fine.

I personally see no reason why browserify-shim is a dependency instead of a devDependency, it's only used when bundling with browserify which only affects running the specs right now, since the bundling was migrated to Webpack.

Pinging @rochoa because he moved it there explicitely [3 years ago](https://github.com/CartoDB/carto.js/commit/614ef3efeb5f2b7c8c7af573e50ed9057e667c35) so I wonder there is (o used to be) a reason for this.

I've tried building and running the specs, all works fine apparently.

I'm also fixing webpack to builder's version because I am paranoid now