### PR TITLE
Fix versioning and tags in guides

### DIFF
--- a/docs/guides/01-overview.md
+++ b/docs/guides/01-overview.md
@@ -13,7 +13,7 @@ This conceptual documentation is designed to let you quickly start exploring and
 The easiest way to start learning about the CARTO.js library is to see a simple example. The following web page displays a map adding a layer over it.
 
 ```html
-      <!DOCTYPE html>
+<!DOCTYPE html>
 <html>
   <head>
     <title>Single layer | CARTO</title>
@@ -129,7 +129,7 @@ The URL contained in the script tag is the location of a JavaScript file that lo
 #### HTTPS or HTTP
 We think security on the web is pretty important, and recommend using HTTPS whenever possible. As part of our efforts to make the web more secure, we've made all of the CARTO components available over HTTPS. Using HTTPS encryption makes your site more secure, and more resistant to snooping or tampering.
 
-We recommend loading the CARTO.js library over HTTPS using the <script> tag provided above.
+We recommend loading the CARTO.js library over HTTPS using the `<script>` tag provided above.
 
 ### Map DOM Elements
 

--- a/docs/guides/01-overview.md
+++ b/docs/guides/01-overview.md
@@ -23,7 +23,7 @@ The easiest way to start learning about the CARTO.js library is to see a simple 
     <script src="https://unpkg.com/leaflet@1.3.1/dist/leaflet.js"></script>
     <link href="https://unpkg.com/leaflet@1.3.1/dist/leaflet.css" rel="stylesheet">
     <!-- Include CARTO.js -->
-    <script src="https://libs.cartocdn.com/carto.js/v4.0.8/carto.min.js"></script>
+    <script src="https://libs.cartocdn.com/carto.js/%VERSION%/carto.min.js"></script>
     <link href="https://fonts.googleapis.com/css?family=Montserrat:600" rel="stylesheet">
     <link href="https://fonts.googleapis.com/css?family=Open+Sans" rel="stylesheet">
     <link href="https://carto.com/developers/carto-js/examples/maps/public/style.css" rel="stylesheet">
@@ -121,7 +121,7 @@ This CSS declaration indicates that the map container <div> (with id map) should
 To load the Maps JavaScript API, use a script tag like the one in the following example:
 
 ```html
-<script src="https://libs.cartocdn.com/carto.js/v4.0.8/carto.min.js"></script>
+<script src="https://libs.cartocdn.com/carto.js/%VERSION%/carto.min.js"></script>
 ```
 
 The URL contained in the script tag is the location of a JavaScript file that loads all of the code you need for using the CARTO.js library. This script tag is required. We are using the minified version of the library.

--- a/docs/guides/05-upgrade-considerations.md
+++ b/docs/guides/05-upgrade-considerations.md
@@ -104,7 +104,7 @@ The following example shows the application skeleton using version 3.15 of CARTO
 </html>
 ```
 
-In order to make this example work with version 4.0 of CARTO.js, modify the code as follows:
+In order to make this example work with version 4 of CARTO.js, modify the code as follows:
 
 ```html
 <!DOCTYPE html>

--- a/docs/reference/01-introduction.md
+++ b/docs/reference/01-introduction.md
@@ -2,7 +2,7 @@
 
 CARTO.js is a JavaScript library that interacts with different CARTO APIs. It is part of the [CARTO Engine](https://carto.com/pricing/engine/) ecosystem.
 
-To understand the fundamentals of CARTO.js 4.0, [read the guides]({{site.cartojs_docs}}/guides/quickstart/). To view the source code, browse the [open-source repository](https://github.com/CartoDB/carto.js) in Github and contribute. Otherwise, view [examples with Leaflet and Google Maps]({{site.cartojs_docs}}/examples/) or find different [support options]({site.cartojs_docs}}/support/).
+To understand the fundamentals of CARTO.js v4, [read the guides]({{site.cartojs_docs}}/guides/quickstart/). To view the source code, browse the [open-source repository](https://github.com/CartoDB/carto.js) in Github and contribute. Otherwise, view [examples with Leaflet and Google Maps]({{site.cartojs_docs}}/examples/) or find different [support options]({site.cartojs_docs}}/support/).
 
 If you find any trouble understanding any term written in this reference, please visit our [glossary]({{site.cartojs_docs}}/guides/glossary/)
 

--- a/docs/reference/02-authentication.md
+++ b/docs/reference/02-authentication.md
@@ -1,6 +1,6 @@
 ## Authentication
 
-CARTO.js 4.0 requires using an API Key. From your CARTO dashboard, click _[Your API keys](https://carto.com/login)_ from the avatar drop-down menu to view your uniquely generated API Key for managing data with CARTO Engine.
+CARTO.js v4 requires using an API Key. From your CARTO dashboard, click _[Your API keys](https://carto.com/login)_ from the avatar drop-down menu to view your uniquely generated API Key for managing data with CARTO Engine.
 
 ![Your API Keys](../img/avatar.gif)
 

--- a/docs/reference/04-loading-the-library.md
+++ b/docs/reference/04-loading-the-library.md
@@ -4,10 +4,10 @@ CARTO.js is hosted in NPM as well. You can require it as a dependency in your cu
 
 ```html
 <!-- CDN: load the latest CARTO.js version -->
-<script src="https://libs.cartocdn.com/carto.js/v4.0.8/carto.min.js"></script>
+<script src="https://libs.cartocdn.com/carto.js/%VERSION%/carto.min.js"></script>
 
 <!-- CDN: load a specific CARTO.js version-->
-<script src="https://libs.cartocdn.com/carto.js/%VERSION%/carto.min.js"></script>
+<script src="https://libs.cartocdn.com/carto.js/%REPLACE_WITH_VERSION%/carto.min.js"></script>
 ```
 
 ```javascript

--- a/docs/reference/04-loading-the-library.md
+++ b/docs/reference/04-loading-the-library.md
@@ -4,10 +4,10 @@ CARTO.js is hosted in NPM as well. You can require it as a dependency in your cu
 
 ```html
 <!-- CDN: load the latest CARTO.js version -->
-<script src="https://libs.cartocdn.com/carto.js/%VERSION%/carto.min.js"></script>
+<script src="https://libs.cartocdn.com/carto.js/%CURRENT_VERSION%/carto.min.js"></script>
 
 <!-- CDN: load a specific CARTO.js version-->
-<script src="https://libs.cartocdn.com/carto.js/%REPLACE_WITH_VERSION%/carto.min.js"></script>
+<script src="https://libs.cartocdn.com/carto.js/%VERSION%/carto.min.js"></script>
 ```
 
 ```javascript

--- a/docs/support/02-faq.md
+++ b/docs/support/02-faq.md
@@ -1,6 +1,6 @@
 ## FAQs
 
-CARTO.js 4.0 introduces new concepts that in some cases, change the behavior of old components. This section clarifies those changes and describe new functionality.
+CARTO.js v4 introduces new concepts that in some cases, change the behavior of old components. This section clarifies those changes and describe new functionality.
 
 ### Do I need an API Key?
 
@@ -42,7 +42,7 @@ No, you cannot.
 
 While `cartodb.createVis` and `viz.json` URLs were convenient and allowed you to prototype a map using CARTO Editor (the former version of Builder) to create a custom app, the functionality of the library has changed.
 
-In CARTO.js 4.0, we are taking a more programmatic, low-level approach and identifying components that are separate from the front-end tool (CARTO Builder). This will make the API easier to use and more intuitive, giving developers greater flexibility in maintaining their core application.
+In CARTO.js v4, we are taking a more programmatic, low-level approach and identifying components that are separate from the front-end tool (CARTO Builder). This will make the API easier to use and more intuitive, giving developers greater flexibility in maintaining their core application.
 
 ### Is CartoDB.js v.3.15 still available?
 

--- a/docs/support/05-release-announcement.md
+++ b/docs/support/05-release-announcement.md
@@ -1,6 +1,6 @@
 ## v4 Release Announcement
 
-After several months of hard work, CARTO is very proud to announce the __final release of CARTO.js 4.0__, which replaces our existing CartoDB.js library. We recognize that you have been anticipating an updated version for some time so before we give you the details, thank you for your patience!
+After several months of hard work, CARTO is very proud to announce the __final release of CARTO.js v4__, which replaces our existing CartoDB.js library. We recognize that you have been anticipating an updated version for some time so before we give you the details, thank you for your patience!
 
 The updated CARTO.js library has been __rebuilt from the ground up__. Case Studies indicated that we could change how we structured the API to make it more intuitive for developers. As a result, we created __a more low-level, programmatic approach__ which makes it easier to use and allows you to create fully customized location intelligence apps.
 
@@ -12,6 +12,6 @@ Some of the key features of the Beta release are:
 
 We know that documentation is critical for any good JS library and used this as an opportunity to begin the redesign of how we provide documentation for all of our CARTO platform. Browse the interactive API documentation for the final release to search for specific CARTO.js methods, arguments, and sample code that can be used to build your applications.
 
-Please use the final release and <a class="typeform-share" href="https://cartohq.typeform.com/to/mH6RRl" data-mode="popup" target="_blank">let us know what you think!</a><script>(function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm_share", b="https://embed.typeform.com/"; if(!gi.call(d,id)){ js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })() </script> The goal is to gather as much feedback as possible so that we can ensure CARTO.js 4.0 is rock-solid and super useful for all CARTO users. You can find different [support-options]({{site.cartojs_docs}}/support) if you need help.
+Please use the final release and <a class="typeform-share" href="https://cartohq.typeform.com/to/mH6RRl" data-mode="popup" target="_blank">let us know what you think!</a><script>(function() { var qs,js,q,s,d=document, gi=d.getElementById, ce=d.createElement, gt=d.getElementsByTagName, id="typef_orm_share", b="https://embed.typeform.com/"; if(!gi.call(d,id)){ js=ce.call(d,"script"); js.id=id; js.src=b+"embed.js"; q=gt.call(d,"script")[0]; q.parentNode.insertBefore(js,q) } })() </script> The goal is to gather as much feedback as possible so that we can ensure CARTO.js v4 is rock-solid and super useful for all CARTO users. You can find different [support-options]({{site.cartojs_docs}}/support) if you need help.
 
 __Happy coding!__


### PR DESCRIPTION
Related to: https://github.com/CartoDB/carto.js/issues/2182

It includes fixes to two issues:

1. On the reference page. Since @Jesus89 already made a PR including the string replace task for the reference page, the `Loading the library` section would be as follows:

```
<!-- CDN: load the latest CARTO.js version -->
<script src="https://libs.cartocdn.com/carto.js/%CURRENT_VERSION%/carto.min.js"></script>
<!-- CDN: load a specific CARTO.js version-->
<script src="https://libs.cartocdn.com/carto.js/%VERSION%/carto.min.js"></script>
```

`%CURRENT_VERSION%` will be replaced by the newest tag (specified in https://github.com/CartoDB/developers/blob/master/_app/_data/technologies.yml#L153) 
`%VERSION%` will remain the same to show where the version should be specified to load a different one.


2. Replacing `4.0` with `v4` in guides

These changes will be live when a new tag is ready and updated in the developer center
[here](https://github.com/CartoDB/developers/blob/master/_app/_data/technologies.yml#L134)  and [here](https://github.com/CartoDB/developers/blob/master/grunt-tasks/config.js#L14 ) since the fetching of latest tag is not automatic.