### PR TITLE
Add new tomtom geocoder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Moved 'browserify-shim' to devDependencies, fixing a potential problem with npm shrinkwrap.
+
+## 4.1.9 - 2019-01-09
+### Added
+- TomTom geocoder service
+
 ## 4.1.8 - 2018-10-29
 ### Fixed
 - Moved 'browserify-shim' to devDependencies, fixing a potential problem with npm shrinkwrap.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,17 +9,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
-## 4.1.9 - 2019-01-09
 ### Added
-- TomTom geocoder service
+- TomTom geocoder service [#2213](https://github.com/CartoDB/carto.js/issues/2213) 
+
+### Fixed
 - Histogram: fix wrong selection in last bucket.
+
+### Changed
+- Improve examples. [#2211](https://github.com/CartoDB/carto.js/pull/2211)
 
 ## 4.1.8 - 2018-10-29
 ### Fixed
 - Moved 'browserify-shim' to devDependencies, fixing a potential problem with npm shrinkwrap.
-
-### Changed
-- Improve examples. [#2211](https://github.com/CartoDB/carto.js/pull/2211)
 
 ## 4.1.7 - 2018-10-18
 ### Fixed

--- a/src/geo/geocoder/tomtom-geocoder.js
+++ b/src/geo/geocoder/tomtom-geocoder.js
@@ -1,0 +1,82 @@
+var ENDPOINT = 'https://api.tomtom.com/search/2/search/{{address}}.json?key={{apiKey}}';
+
+var TYPES = {
+  'POI': 'venue',
+  'Street': 'neighbourhood',
+  'Geography': 'region',
+  'Point Address': 'address',
+  'Address Range': 'neighbourhood',
+  'Cross Street': 'address'
+};
+
+function TomTomGeocoder () { }
+
+TomTomGeocoder.geocode = function (address, apiKey) {
+  if (!address) {
+    throw new Error('TomTomGeocoder.geocode called with no address');
+  }
+  if (!apiKey) {
+    throw new Error('TomTomGeocoder.geocode called with no apiKey');
+  }
+  return fetch(ENDPOINT.replace('{{address}}', address).replace('{{apiKey}}', apiKey))
+    .then(function (response) {
+      return response.json();
+    })
+    .then(function (response) {
+      return _formatResponse(response);
+    });
+};
+
+/**
+ * Transform a tomtom geocoder response into an object more friendly for our search widget.
+ * @param {object} rawTomTomResponse - The raw tomtom geocoding response, {@see https://developer.tomtom.com/search-api/search-api-documentation-geocoding/geocode}
+ */
+function _formatResponse (rawTomTomResponse) {
+  if (!rawTomTomResponse.results.length) {
+    return [];
+  }
+
+  const bestCandidate = rawTomTomResponse.results[0];
+  return [{
+    boundingbox: _getBoundingBox(bestCandidate),
+    center: _getCenter(bestCandidate),
+    type: _getType(bestCandidate)
+  }];
+}
+
+/**
+ * TomTom returns { lon, lat } while we use [lat, lon]
+ */
+function _getCenter (result) {
+  return [result.position.lat, result.position.lon];
+}
+
+/**
+ * Transform the feature type into a well known enum.
+ */
+function _getType (result) {
+  if (TYPES[result.type]) {
+    return TYPES[result.type];
+  }
+  return 'default';
+}
+
+/**
+ * Transform the feature bbox into a carto.js well known format.
+ */
+function _getBoundingBox (result) {
+  if (!result.viewport) {
+    return;
+  }
+  const upperLeft = result.viewport.topLeftPoint;
+  const bottomRight = result.viewport.btmRightPoint;
+
+  return {
+    south: bottomRight.lat,
+    west: upperLeft.lon,
+    north: upperLeft.lat,
+    east: bottomRight.lon
+  };
+}
+
+module.exports = TomTomGeocoder;

--- a/src/geo/geocoder/tomtom-geocoder.js
+++ b/src/geo/geocoder/tomtom-geocoder.js
@@ -1,12 +1,20 @@
 var ENDPOINT = 'https://api.tomtom.com/search/2/search/{{address}}.json?key={{apiKey}}';
 
 var TYPES = {
-  'POI': 'venue',
-  'Street': 'neighbourhood',
   'Geography': 'region',
-  'Point Address': 'address',
+  'Geography:Country': 'country',
+  'Geography:CountrySubdivision': 'region',
+  'Geography:CountrySecondarySubdivision': 'region',
+  'Geography:CountryTertiarySubdivision': 'region',
+  'Geography:Municipality': 'localadmin',
+  'Geography:MunicipalitySubdivision': 'locality',
+  'Geography:Neighbourhood': 'neighbourhood',
+  'Geography:PostalCodeArea': 'postal-area',
+  'Street': 'neighbourhood',
   'Address Range': 'neighbourhood',
-  'Cross Street': 'address'
+  'Point Address': 'address',
+  'Cross Street': 'address',
+  'POI': 'venue'
 };
 
 function TomTomGeocoder () { }
@@ -55,9 +63,14 @@ function _getCenter (result) {
  * Transform the feature type into a well known enum.
  */
 function _getType (result) {
-  if (TYPES[result.type]) {
-    return TYPES[result.type];
+  let type = result.type;
+  if (TYPES[type]) {
+    if (type === 'Geography' && result.entityType) {
+      type = type + ':' + result.entityType;
+    }
+    return TYPES[type];
   }
+
   return 'default';
 }
 

--- a/src/geo/ui/search/search.js
+++ b/src/geo/ui/search/search.js
@@ -15,16 +15,16 @@ var Search = View.extend({
   className: 'CDB-Search CDB-Overlay',
 
   _ZOOM_BY_CATEGORY: {
-    'building': 18,
-    'postal-area': 15,
-    'venue': 18,
-    'region': 8,
     'address': 18,
-    'country': 5,
-    'county': 8,
+    'building': 18,
+    'venue': 18,
+    'postal-area': 15,
+    'neighbourhood': 15,
     'locality': 12,
     'localadmin': 11,
-    'neighbourhood': 15,
+    'region': 8,
+    'county': 8,
+    'country': 5,
     'default': 12
   },
 

--- a/src/geo/ui/search/search.js
+++ b/src/geo/ui/search/search.js
@@ -71,11 +71,6 @@ var Search = View.extend({
     this.geocoder = GEOCODERS[this.geocoderService];
 
     const windowApiKey = GEOCODERS_WINDOW_API_KEYS[this.geocoderService];
-
-    if (!this.options.token && !window[windowApiKey]) {
-      throw new Error('There is no valid api key for ' + this.geocoder + ' geocoder.');
-    }
-
     this.token = this.options.token || window[windowApiKey];
   },
 

--- a/src/geo/ui/search/search.js
+++ b/src/geo/ui/search/search.js
@@ -71,7 +71,12 @@ var Search = View.extend({
     this.geocoder = GEOCODERS[this.geocoderService];
 
     const windowApiKey = GEOCODERS_WINDOW_API_KEYS[this.geocoderService];
-    this.token = this.options.token || windowApiKey;
+
+    if (!this.options.token && !window[windowApiKey]) {
+      throw new Error('There is no valid api key for ' + this.geocoder + ' geocoder.');
+    }
+
+    this.token = this.options.token || window[windowApiKey];
   },
 
   render: function () {

--- a/test/spec/geo/geocoder/tomtom-geocoder-response-0.json
+++ b/test/spec/geo/geocoder/tomtom-geocoder-response-0.json
@@ -1,0 +1,445 @@
+{
+  "summary": {
+    "query": "santander",
+    "queryType": "NON_NEAR",
+    "queryTime": 39,
+    "numResults": 10,
+    "offset": 0,
+    "totalResults": 24811,
+    "fuzzyLevel": 1
+  },
+  "results": [
+    {
+      "type": "Geography",
+      "id": "ES/GEO/p0/7661",
+      "score": 2.418,
+      "entityType": "Municipality",
+      "address": {
+        "municipality": "Santander",
+        "countrySecondarySubdivision": "Cantabria",
+        "countrySubdivision": "Cantabria",
+        "countryCode": "ES",
+        "country": "Spain",
+        "countryCodeISO3": "ESP",
+        "freeformAddress": "Santander"
+      },
+      "position": {
+        "lat": 43.46141,
+        "lon": -3.8093
+      },
+      "viewport": {
+        "topLeftPoint": {
+          "lat": 43.49482,
+          "lon": -3.88905
+        },
+        "btmRightPoint": {
+          "lat": 43.43446,
+          "lon": -3.76325
+        }
+      },
+      "boundingBox": {
+        "topLeftPoint": {
+          "lat": 43.49482,
+          "lon": -3.88905
+        },
+        "btmRightPoint": {
+          "lat": 43.43446,
+          "lon": -3.76325
+        }
+      },
+      "dataSources": {
+        "geometry": {
+          "id": "00005858-5800-1200-0000-00007d2e35e3"
+        }
+      }
+    },
+    {
+      "type": "Geography",
+      "id": "PH/GEO/p0/1587",
+      "score": 2.382,
+      "entityType": "Municipality",
+      "address": {
+        "municipality": "Santander",
+        "countrySecondarySubdivision": "Cebu",
+        "countrySubdivision": "Central Visayas",
+        "countryCode": "PH",
+        "country": "Philippines",
+        "countryCodeISO3": "PHL",
+        "freeformAddress": "Santander, Central Visayas"
+      },
+      "position": {
+        "lat": 9.42242,
+        "lon": 123.30378
+      },
+      "viewport": {
+        "topLeftPoint": {
+          "lat": 9.47779,
+          "lon": 123.29687
+        },
+        "btmRightPoint": {
+          "lat": 9.41298,
+          "lon": 123.3632
+        }
+      },
+      "boundingBox": {
+        "topLeftPoint": {
+          "lat": 9.47779,
+          "lon": 123.29687
+        },
+        "btmRightPoint": {
+          "lat": 9.41298,
+          "lon": 123.3632
+        }
+      },
+      "dataSources": {
+        "geometry": {
+          "id": "00005858-5800-1200-0000-000077378fa7"
+        }
+      }
+    },
+    {
+      "type": "Geography",
+      "id": "MX/GEO/p0/340",
+      "score": 2.362,
+      "entityType": "Municipality",
+      "address": {
+        "municipality": "Jiménez",
+        "countrySubdivision": "Tamaulipas",
+        "countryCode": "MX",
+        "country": "Mexico",
+        "countryCodeISO3": "MEX",
+        "freeformAddress": "Jiménez"
+      },
+      "position": {
+        "lat": 24.21378,
+        "lon": -98.48187
+      },
+      "viewport": {
+        "topLeftPoint": {
+          "lat": 24.47171,
+          "lon": -98.72639
+        },
+        "btmRightPoint": {
+          "lat": 23.93939,
+          "lon": -98.27799
+        }
+      },
+      "boundingBox": {
+        "topLeftPoint": {
+          "lat": 24.47171,
+          "lon": -98.72639
+        },
+        "btmRightPoint": {
+          "lat": 23.93939,
+          "lon": -98.27799
+        }
+      },
+      "dataSources": {
+        "geometry": {
+          "id": "00005858-5800-1200-0000-00007737d289"
+        }
+      }
+    },
+    {
+      "type": "Geography",
+      "id": "CO/GEO/p0/252",
+      "score": 2.36,
+      "entityType": "Municipality",
+      "address": {
+        "municipality": "Puerto Santander",
+        "countrySubdivision": "Norte de Santander",
+        "countryCode": "CO",
+        "country": "Colombia",
+        "countryCodeISO3": "COL",
+        "freeformAddress": "Puerto Santander, Norte de Santander"
+      },
+      "position": {
+        "lat": 8.36227,
+        "lon": -72.40896
+      },
+      "viewport": {
+        "topLeftPoint": {
+          "lat": 8.38354,
+          "lon": -72.4475
+        },
+        "btmRightPoint": {
+          "lat": 8.26839,
+          "lon": -72.38042
+        }
+      },
+      "boundingBox": {
+        "topLeftPoint": {
+          "lat": 8.38354,
+          "lon": -72.4475
+        },
+        "btmRightPoint": {
+          "lat": 8.26839,
+          "lon": -72.38042
+        }
+      },
+      "dataSources": {
+        "geometry": {
+          "id": "00005858-5800-1200-0000-00007d30e01c"
+        }
+      }
+    },
+    {
+      "type": "Geography",
+      "id": "CO/GEO/p0/888",
+      "score": 2.358,
+      "entityType": "Municipality",
+      "address": {
+        "municipality": "Santander",
+        "countrySubdivision": "Amazonas",
+        "countryCode": "CO",
+        "country": "Colombia",
+        "countryCodeISO3": "COL",
+        "freeformAddress": "Santander, Amazonas"
+      },
+      "position": {
+        "lat": -0.62217,
+        "lon": -72.38281
+      },
+      "viewport": {
+        "topLeftPoint": {
+          "lat": -0.26464,
+          "lon": -72.99754
+        },
+        "btmRightPoint": {
+          "lat": -1.89121,
+          "lon": -70.72647
+        }
+      },
+      "boundingBox": {
+        "topLeftPoint": {
+          "lat": -0.26464,
+          "lon": -72.99754
+        },
+        "btmRightPoint": {
+          "lat": -1.89121,
+          "lon": -70.72647
+        }
+      },
+      "dataSources": {
+        "geometry": {
+          "id": "00005858-5800-1200-0000-00007d30ef7b"
+        }
+      }
+    },
+    {
+      "type": "Geography",
+      "id": "CO/GEO/p0/1010",
+      "score": 2.341,
+      "entityType": "Municipality",
+      "address": {
+        "municipality": "Santander de Quilichao",
+        "countrySubdivision": "Cauca",
+        "countryCode": "CO",
+        "country": "Colombia",
+        "countryCodeISO3": "COL",
+        "freeformAddress": "Santander de Quilichao, Cauca"
+      },
+      "position": {
+        "lat": 3.00879,
+        "lon": -76.4859
+      },
+      "viewport": {
+        "topLeftPoint": {
+          "lat": 3.1493,
+          "lon": -76.61535
+        },
+        "btmRightPoint": {
+          "lat": 2.8461,
+          "lon": -76.37358
+        }
+      },
+      "boundingBox": {
+        "topLeftPoint": {
+          "lat": 3.1493,
+          "lon": -76.61535
+        },
+        "btmRightPoint": {
+          "lat": 2.8461,
+          "lon": -76.37358
+        }
+      },
+      "dataSources": {
+        "geometry": {
+          "id": "00005858-5800-1200-0000-00007d30eff7"
+        }
+      }
+    },
+    {
+      "type": "Geography",
+      "id": "CO/GEO/p0/6",
+      "score": 2.255,
+      "entityType": "CountrySubdivision",
+      "address": {
+        "countrySubdivision": "Santander",
+        "countryCode": "CO",
+        "country": "Colombia",
+        "countryCodeISO3": "COL",
+        "freeformAddress": "Santander"
+      },
+      "position": {
+        "lat": 6.92507,
+        "lon": -73.50153
+      },
+      "viewport": {
+        "topLeftPoint": {
+          "lat": 8.14342,
+          "lon": -74.52666
+        },
+        "btmRightPoint": {
+          "lat": 5.70671,
+          "lon": -72.4764
+        }
+      },
+      "boundingBox": {
+        "topLeftPoint": {
+          "lat": 8.14342,
+          "lon": -74.52666
+        },
+        "btmRightPoint": {
+          "lat": 5.70671,
+          "lon": -72.4764
+        }
+      },
+      "dataSources": {
+        "geometry": {
+          "id": "00005858-5800-1200-0000-000077374466"
+        }
+      }
+    },
+    {
+      "type": "Geography",
+      "id": "CO/GEO/p0/5",
+      "score": 2.211,
+      "entityType": "CountrySubdivision",
+      "address": {
+        "countrySubdivision": "Norte de Santander",
+        "countryCode": "CO",
+        "country": "Colombia",
+        "countryCodeISO3": "COL",
+        "freeformAddress": "Norte de Santander"
+      },
+      "position": {
+        "lat": 8.08458,
+        "lon": -72.84278
+      },
+      "viewport": {
+        "topLeftPoint": {
+          "lat": 9.2961,
+          "lon": -73.63743
+        },
+        "btmRightPoint": {
+          "lat": 6.87306,
+          "lon": -72.04813
+        }
+      },
+      "boundingBox": {
+        "topLeftPoint": {
+          "lat": 9.2961,
+          "lon": -73.63743
+        },
+        "btmRightPoint": {
+          "lat": 6.87306,
+          "lon": -72.04813
+        }
+      },
+      "dataSources": {
+        "geometry": {
+          "id": "00005858-5800-1200-0000-000077374465"
+        }
+      }
+    },
+    {
+      "type": "Geography",
+      "id": "CO/GEO/p0/1668",
+      "score": 2.177,
+      "entityType": "MunicipalitySubdivision",
+      "address": {
+        "municipalitySubdivision": "Santander",
+        "municipality": "Cali",
+        "countrySubdivision": "Valle del Cauca",
+        "countryCode": "CO",
+        "country": "Colombia",
+        "countryCodeISO3": "COL",
+        "freeformAddress": "Cali Santander, Valle del Cauca"
+      },
+      "position": {
+        "lat": 3.46266,
+        "lon": -76.51554
+      },
+      "viewport": {
+        "topLeftPoint": {
+          "lat": 3.4665,
+          "lon": -76.52026
+        },
+        "btmRightPoint": {
+          "lat": 3.45905,
+          "lon": -76.51054
+        }
+      },
+      "boundingBox": {
+        "topLeftPoint": {
+          "lat": 3.4665,
+          "lon": -76.52026
+        },
+        "btmRightPoint": {
+          "lat": 3.45905,
+          "lon": -76.51054
+        }
+      },
+      "dataSources": {
+        "geometry": {
+          "id": "0000434f-3300-3c00-0000-000065ec89e3"
+        }
+      }
+    },
+    {
+      "type": "Geography",
+      "id": "CO/GEO/p0/2477",
+      "score": 2.177,
+      "entityType": "MunicipalitySubdivision",
+      "address": {
+        "municipalitySubdivision": "Santander",
+        "municipality": "Medellín",
+        "countrySubdivision": "Antioquia",
+        "countryCode": "CO",
+        "country": "Colombia",
+        "countryCodeISO3": "COL",
+        "freeformAddress": "Medellín Santander, Antioquia"
+      },
+      "position": {
+        "lat": 6.30768,
+        "lon": -75.57501
+      },
+      "viewport": {
+        "topLeftPoint": {
+          "lat": 6.31099,
+          "lon": -75.57874
+        },
+        "btmRightPoint": {
+          "lat": 6.30185,
+          "lon": -75.57128
+        }
+      },
+      "boundingBox": {
+        "topLeftPoint": {
+          "lat": 6.31099,
+          "lon": -75.57874
+        },
+        "btmRightPoint": {
+          "lat": 6.30185,
+          "lon": -75.57128
+        }
+      },
+      "dataSources": {
+        "geometry": {
+          "id": "0000434f-3200-3c00-0000-000065a03d92"
+        }
+      }
+    }
+  ]
+}

--- a/test/spec/geo/geocoder/tomtom-geocoder.spec.js
+++ b/test/spec/geo/geocoder/tomtom-geocoder.spec.js
@@ -1,0 +1,51 @@
+var tomtomGeocoder = require('../../../../src/geo/geocoder/tomtom-geocoder');
+var API_KEY = 'fake_api_key';
+describe('tomtom-geocoder', function () {
+  describe('.geocode', function () {
+    it('should build the right fetch url (add address and apiKey)', function (done) {
+      spyOn(window, 'fetch').and.returnValue(Promise.resolve({ json: function () { return { results: [] }; } }));
+      tomtomGeocoder.geocode('fake_address', API_KEY).then(function (result) {
+        var expectedFetchUrl = 'https://api.tomtom.com/search/2/search/fake_address.json?key=fake_api_key';
+        expect(window.fetch).toHaveBeenCalledWith(expectedFetchUrl);
+        done();
+      });
+    });
+
+    it('should geocode a city location', function (done) {
+      spyOn(window, 'fetch').and.returnValue(Promise.resolve({ json: function () { return require('./tomtom-geocoder-response-0'); } }));
+      tomtomGeocoder.geocode('Santander', API_KEY)
+        .then(function (results) {
+          expect(results).toBeDefined();
+          done();
+        });
+    });
+
+    it('should return a well formated response [example 0]', function (done) {
+      spyOn(window, 'fetch').and.returnValue(Promise.resolve({ json: function () { return require('./tomtom-geocoder-response-0'); } }));
+      tomtomGeocoder.geocode('Santander', API_KEY)
+        .then(function (results) {
+          let bestCandidate = results[0];
+          expect(bestCandidate.center).toBeDefined();
+          expect(bestCandidate.center[0]).toEqual(43.46141); // lat
+          expect(bestCandidate.center[1]).toEqual(-3.8093); // lon
+          // Bbox
+          expect(bestCandidate.boundingbox.south).toEqual(43.43446);
+          expect(bestCandidate.boundingbox.west).toEqual(-3.88905);
+          expect(bestCandidate.boundingbox.north).toEqual(43.49482);
+          expect(bestCandidate.boundingbox.east).toEqual(-3.76325);
+          // Type
+          expect(bestCandidate.type).toEqual('localadmin');
+          done();
+        }).catch(console.error);
+    });
+
+    it('should return an empty array when the response is empty', function (done) {
+      spyOn(window, 'fetch').and.returnValue(Promise.resolve({ json: function () { return { results: [] }; } }));
+      tomtomGeocoder.geocode('ABCDEFGHIJ', API_KEY)
+        .then(function (result) {
+          expect(result).toEqual([]);
+          done();
+        });
+    });
+  });
+});

--- a/test/spec/geo/ui/search.spec.js
+++ b/test/spec/geo/ui/search.spec.js
@@ -3,7 +3,7 @@ var Backbone = require('backbone');
 var Search = require('../../../../src/geo/ui/search/search');
 
 var mapboxGeocoder = require('../../../../src/geo/geocoder/mapbox-geocoder');
-// var tomtomGeocoder = require('../../../../src/geo/geocoder/tomtom-geocoder');
+var tomtomGeocoder = require('../../../../src/geo/geocoder/tomtom-geocoder');
 
 var Map = require('../../../../src/geo/map');
 var LeafletMapView = require('../../../../src/geo/leaflet/leaflet-map-view');
@@ -31,22 +31,21 @@ describe('geo/ui/search', function () {
     this.view = new Search({
       model: this.map,
       mapView: this.mapView,
-      geocoderService: 'mapbox', // <<<
-      token: 'pk.eyJ1IjoiY2FydG8tdGVhbSIsImEiOiJjamNseTl3ZzQwZnFkMndudnIydnJoMXZxIn0.HycQBkaaV7ZwLkHm5hEmfg'
+      token: 'a_valid_api_key'
     });
     this.view.render();
   });
 
-  // it('should use tomtom geocoder by default', function () {
-  //   expect(this.view.geocoder).toBe(tomtomGeocoder);
-  // });
+  it('should use tomtom geocoder by default', function () {
+    expect(this.view.geocoder).toBe(tomtomGeocoder);
+  });
 
   it('should allow changing geocoder easily', function () {
     var search = new Search({
       model: this.map,
       mapView: this.mapView,
       geocoderService: 'mapbox', // <<<
-      token: 'pk.eyJ1IjoiY2FydG8tdGVhbSIsImEiOiJjamNseTl3ZzQwZnFkMndudnIydnJoMXZxIn0.HycQBkaaV7ZwLkHm5hEmfg'
+      token: 'a_valid_mapbox_api_key'
     });
     expect(search.geocoder).toBe(mapboxGeocoder);
   });
@@ -71,7 +70,11 @@ describe('geo/ui/search', function () {
         },
         type: undefined
       };
-      spyOn(this.view.geocoder, 'geocode').and.callThrough();
+      // spyOn(this.view.geocoder, 'geocode').and.callThrough();
+      spyOn(this.view.geocoder, 'geocode').and.returnValue(Promise.resolve([{
+        center: [40.41889, -3.69194],
+        type: 'localadmin'
+      }]));
       this.view.$('.js-textInput').val('Madrid, Spain');
     });
 

--- a/test/spec/geo/ui/search.spec.js
+++ b/test/spec/geo/ui/search.spec.js
@@ -1,7 +1,10 @@
 var $ = require('jquery');
 var Backbone = require('backbone');
 var Search = require('../../../../src/geo/ui/search/search');
-var geocoder = require('../../../../src/geo/geocoder/mapbox-geocoder');
+
+var mapboxGeocoder = require('../../../../src/geo/geocoder/mapbox-geocoder');
+// var tomtomGeocoder = require('../../../../src/geo/geocoder/tomtom-geocoder');
+
 var Map = require('../../../../src/geo/map');
 var LeafletMapView = require('../../../../src/geo/leaflet/leaflet-map-view');
 var fakeEvent = {
@@ -28,9 +31,24 @@ describe('geo/ui/search', function () {
     this.view = new Search({
       model: this.map,
       mapView: this.mapView,
+      geocoderService: 'mapbox', // <<<
       token: 'pk.eyJ1IjoiY2FydG8tdGVhbSIsImEiOiJjamNseTl3ZzQwZnFkMndudnIydnJoMXZxIn0.HycQBkaaV7ZwLkHm5hEmfg'
     });
     this.view.render();
+  });
+
+  // it('should use tomtom geocoder by default', function () {
+  //   expect(this.view.geocoder).toBe(tomtomGeocoder);
+  // });
+
+  it('should allow changing geocoder easily', function () {
+    var search = new Search({
+      model: this.map,
+      mapView: this.mapView,
+      geocoderService: 'mapbox', // <<<
+      token: 'pk.eyJ1IjoiY2FydG8tdGVhbSIsImEiOiJjamNseTl3ZzQwZnFkMndudnIydnJoMXZxIn0.HycQBkaaV7ZwLkHm5hEmfg'
+    });
+    expect(search.geocoder).toBe(mapboxGeocoder);
   });
 
   it('should render properly', function () {
@@ -53,13 +71,13 @@ describe('geo/ui/search', function () {
         },
         type: undefined
       };
-      spyOn(geocoder, 'geocode').and.callThrough();
+      spyOn(this.view.geocoder, 'geocode').and.callThrough();
       this.view.$('.js-textInput').val('Madrid, Spain');
     });
 
     it('should search with geocoder when form is submit', function () {
       this.view.$('.js-form').submit();
-      expect(geocoder.geocode).toHaveBeenCalled();
+      expect(this.view.geocoder.geocode).toHaveBeenCalled();
     });
 
     it('should change map center when geocoder returns any result', function (done) {
@@ -74,7 +92,7 @@ describe('geo/ui/search', function () {
 
     describe('result zoom', function () {
       function testZoom (context, featureType, expectedZoom, done) {
-        geocoder.geocode.and.returnValue(Promise.resolve([{
+        context.view.geocoder.geocode.and.returnValue(Promise.resolve([{
           center: [43.0, -3],
           type: featureType
         }]));


### PR DESCRIPTION

![tomtom-search](https://user-images.githubusercontent.com/3824953/50897872-b8dafb00-140d-11e9-8172-d4fcb2cb8012.gif)

### Related to https://github.com/CartoDB/carto.js/issues/2213

Objectives:

- [x] Add new tomtom geocoder provider
- [x] Connect it as default to the 'search bar'
- [x] (optional...) improve the provider selection, to change more easily in the future (hopefully).

This process is very similar to what we did in: https://github.com/CartoDB/carto.js/pull/2020