### PR TITLE
Fix filter "between" using dates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+- Filters: parse dates properly in the `between` filter.
+
 ## 4.1.9 - 2019-01-09
 
 ### Added

--- a/src/api/v4/filter/base-sql.js
+++ b/src/api/v4/filter/base-sql.js
@@ -140,63 +140,30 @@ class SQLBase extends Base {
     }
 
     if (_.isArray(filterValue)) {
-      if (_.isEmpty(filterValue)) {
-        return filterValue;
-      }
-
       return filterValue
-        .map(value => this._convertToString(value))
+        .map(value => this._convertValueToSQLString(value))
         .join(',');
     }
 
     if (_.isObject(filterValue)) {
-      if (_.isEmpty(filterValue)) {
-        return filterValue;
-      }
+      Object
+        .keys(filterValue)
+        .forEach(key => {
+          if (key === 'query') {
+            return;
+          }
 
-      const values = {};
+          filterValue[key] = this._convertValueToSQLString(filterValue[key]);
+        });
 
-      Object.keys(filterValue).forEach(value => {
-        const stringValue = this._convertToStringFromObject(filterValue[value]);
-        values[value] = stringValue;
-      });
-
-      return values;
-    }
-
-    return this._convertToString(filterValue);
-  }
-
-  _convertToString (filterValue) {
-    if (_.isDate(filterValue)) {
-      return `'${filterValue.toISOString()}'`;
+      return filterValue;
     }
 
     if (_.isNumber(filterValue)) {
       return filterValue;
-    }
-
-    if (_.isString()) {
-      return `'${normalizeString(filterValue)}'`;
     }
 
     return `'${normalizeString(filterValue.toString())}'`;
-  }
-
-  _convertToStringFromObject (filterValue) {
-    if (_.isDate(filterValue)) {
-      return `'${filterValue.toISOString()}'`;
-    }
-
-    if (_.isNumber(filterValue)) {
-      return filterValue;
-    }
-
-    if (_.isString()) {
-      return `${normalizeString(filterValue)}`;
-    }
-
-    return `${normalizeString(filterValue.toString())}`;
   }
 
   _interpolateFilter (filterType, filterValues) {

--- a/src/api/v4/filter/base-sql.js
+++ b/src/api/v4/filter/base-sql.js
@@ -135,7 +135,15 @@ class SQLBase extends Base {
   }
 
   _convertValueToSQLString (filterValue) {
-    if (_.isObject(filterValue) && _.isArray(filterValue)) {
+    if (_.isDate(filterValue)) {
+      return `'${filterValue.toISOString()}'`;
+    }
+
+    if (_.isArray(filterValue)) {
+      if (_.isEmpty(filterValue)) {
+        return filterValue;
+      }
+
       return filterValue
         .map(value => this._convertToString(value))
         .join(',');
@@ -149,7 +157,8 @@ class SQLBase extends Base {
       const values = {};
 
       Object.keys(filterValue).forEach(value => {
-        values[value] = this._convertToString(filterValue[value]);
+        const stringValue = this._convertToStringFromObject(filterValue[value]);
+        values[value] = stringValue;
       });
 
       return values;
@@ -160,7 +169,7 @@ class SQLBase extends Base {
 
   _convertToString (filterValue) {
     if (_.isDate(filterValue)) {
-      return `${filterValue.toISOString()}`;
+      return `'${filterValue.toISOString()}'`;
     }
 
     if (_.isNumber(filterValue)) {
@@ -172,6 +181,22 @@ class SQLBase extends Base {
     }
 
     return `'${normalizeString(filterValue.toString())}'`;
+  }
+
+  _convertToStringFromObject (filterValue) {
+    if (_.isDate(filterValue)) {
+      return `'${filterValue.toISOString()}'`;
+    }
+
+    if (_.isNumber(filterValue)) {
+      return filterValue;
+    }
+
+    if (_.isString()) {
+      return `${normalizeString(filterValue)}`;
+    }
+
+    return `${normalizeString(filterValue.toString())}`;
   }
 
   _interpolateFilter (filterType, filterValues) {

--- a/src/api/v4/filter/base-sql.js
+++ b/src/api/v4/filter/base-sql.js
@@ -145,16 +145,26 @@ class SQLBase extends Base {
         .join(',');
     }
 
-    if (_.isObject(filterValue) || _.isNumber(filterValue)) {
+    if (_.isNumber(filterValue)) {
       return filterValue;
+    }
+
+    if (_.isObject(filterValue) && !_.isEmpty(filterValue)) {
+      const values = {};
+
+      Object.keys(filterValue).forEach(function (value) {
+        values[value] = this._convertValueToSQLString(filterValue[value]);
+      }.bind(this));
+
+      return values;
     }
 
     return `'${normalizeString(filterValue.toString())}'`;
   }
 
-  _interpolateFilter (filterType, filterValue) {
+  _interpolateFilter (filterType, filterValues) {
     const sqlString = _.template(this.SQL_TEMPLATES[filterType]);
-    return sqlString({ column: this._column, value: this._convertValueToSQLString(filterValue) });
+    return sqlString({ column: this._column, value: this._convertValueToSQLString(filterValues) });  
   }
 
   _includeNullInQuery (sql) {

--- a/test/spec/api/v4/filter/base-sql.spec.js
+++ b/test/spec/api/v4/filter/base-sql.spec.js
@@ -195,7 +195,7 @@ describe('api/v4/filter/base-sql', function () {
       const sqlFilter = new SQLBase(column);
 
       const fakeDate = new Date('Thu Jun 28 2018 15:04:31 GMT+0200 (Central European Summer Time)');
-      expect(sqlFilter._convertValueToSQLString(fakeDate)).toBe('2018-06-28T13:04:31.000Z'");
+      expect(sqlFilter._convertValueToSQLString(fakeDate)).toBe('\'2018-06-28T13:04:31.000Z\'');
     });
 
     it('should convert array to a comma-separated string wrapped by single comma', function () {
@@ -224,7 +224,7 @@ describe('api/v4/filter/base-sql', function () {
 
       const fakeObject = { fakeDate: new Date('2014-01-01T00:00:00.00Z') };
 
-      expect(sqlFilter._convertValueToSQLString(fakeObject)).toEqual({ fakeDate: "'2014-01-01T00:00:00.000Z'" });
+      expect(sqlFilter._convertValueToSQLString(fakeObject)).toEqual({ fakeDate: '\'2014-01-01T00:00:00.000Z\'' });
     });
 
     it('should wrap strings in single-quotes', function () {

--- a/test/spec/api/v4/filter/base-sql.spec.js
+++ b/test/spec/api/v4/filter/base-sql.spec.js
@@ -211,12 +211,20 @@ describe('api/v4/filter/base-sql', function () {
       expect(sqlFilter._convertValueToSQLString(1)).toBe(1);
     });
 
-    it('should return object without modifying', function () {
+    it('should return object with string values without modifying', function () {
       const sqlFilter = new SQLBase(column);
 
       const fakeObject = { fakeProperty: 'fakeValue' };
 
       expect(sqlFilter._convertValueToSQLString(fakeObject)).toBe(fakeObject);
+    });
+
+    it('should return object with date values parsed properly', function () {
+      const sqlFilter = new SQLBase(column);
+
+      const fakeObject = { fakeDate: new Date('2014-01-01T00:00:00.00Z') };
+
+      expect(sqlFilter._convertValueToSQLString(fakeObject)).toBe({ fakeDate: '2014-01-01T00:00:00.000Z' });
     });
 
     it('should wrap strings in single-quotes', function () {

--- a/test/spec/api/v4/filter/base-sql.spec.js
+++ b/test/spec/api/v4/filter/base-sql.spec.js
@@ -195,7 +195,7 @@ describe('api/v4/filter/base-sql', function () {
       const sqlFilter = new SQLBase(column);
 
       const fakeDate = new Date('Thu Jun 28 2018 15:04:31 GMT+0200 (Central European Summer Time)');
-      expect(sqlFilter._convertValueToSQLString(fakeDate)).toBe("'2018-06-28T13:04:31.000Z'");
+      expect(sqlFilter._convertValueToSQLString(fakeDate)).toBe('2018-06-28T13:04:31.000Z'");
     });
 
     it('should convert array to a comma-separated string wrapped by single comma', function () {
@@ -216,7 +216,7 @@ describe('api/v4/filter/base-sql', function () {
 
       const fakeObject = { fakeProperty: 'fakeValue' };
 
-      expect(sqlFilter._convertValueToSQLString(fakeObject)).toBe(fakeObject);
+      expect(sqlFilter._convertValueToSQLString(fakeObject)).toEqual(fakeObject);
     });
 
     it('should return object with date values parsed properly', function () {
@@ -224,7 +224,7 @@ describe('api/v4/filter/base-sql', function () {
 
       const fakeObject = { fakeDate: new Date('2014-01-01T00:00:00.00Z') };
 
-      expect(sqlFilter._convertValueToSQLString(fakeObject)).toBe({ fakeDate: '2014-01-01T00:00:00.000Z' });
+      expect(sqlFilter._convertValueToSQLString(fakeObject)).toEqual({ fakeDate: "'2014-01-01T00:00:00.000Z'" });
     });
 
     it('should wrap strings in single-quotes', function () {


### PR DESCRIPTION
Fixes Support issue https://github.com/CartoDB/support/issues/1898

# Context
_(copied from the issue)_

The range filter can use dates as follows, using `lte` & `gte` filters:

```js
let mi = new Date("2014-01-01T00:00:00.00Z");
let ma = new Date("2014-12-31T23:59:59.00Z");
let filtreData = new Carto.filter.Range('dat_data', { lte: ma, gte: mi});
```

However, when it uses the `between` filter like the next block of code:

```js
let mi = new Date("2014-01-01T00:00:00.00Z");
let ma = new Date("2014-12-31T23:59:59.00Z");
let filtroData = new Carto.filter.Range('dat_data', {between:{max: ma, min: mi}});
```

It gets the next error message: `message: "syntax error at or near "Jan""`:

![screenshot 2019-01-04 at 10 40 02](https://user-images.githubusercontent.com/11177693/50681866-3b7a4980-100d-11e9-84b6-2c94a5e5680f.png)

File:

[between_test.html.zip](https://github.com/CartoDB/support/files/2726507/between_test.html.zip)

### Steps to Reproduce

1. Create a JS map using a dataset with date or timestamp fields
2. Apply the between filter
3. The map returns an error.