### PR TITLE
Avoid 'silent:true' when setting view after search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 
+### Fixed
+
+- Trigger view update after search [2219](https://github.com/CartoDB/carto.js/pull/2219)
+
 ## 4.1.9 - 2019-01-09
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internal-carto.js",
-  "version": "4.1.9",
+  "version": "4.1.9-trigger-view-after-search",
   "description": "CARTO javascript library",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "internal-carto.js",
-  "version": "4.1.9-trigger-view-after-search",
+  "version": "4.1.9",
   "description": "CARTO javascript library",
   "repository": {
     "type": "git",

--- a/src/geo/map.js
+++ b/src/geo/map.js
@@ -39,6 +39,7 @@ var Map = Model.extend({
     if (typeof center === 'string') {
       center = JSON.parse(center);
     }
+
     this.set({
       center: center,
       original_center: center
@@ -215,13 +216,14 @@ var Map = Model.extend({
 
   // INTERNAL CartoDB.js METHODS
 
-  setView: function (latlng, zoom) {
+  setView: function (latlng, zoom, options) {
+    var setViewOptions = options || { silent: true };
+
     this.set({
       center: latlng,
       zoom: zoom
-    }, {
-      silent: true
-    });
+    }, setViewOptions);
+
     this.trigger('set_view');
   },
 

--- a/src/geo/ui/search/search.js
+++ b/src/geo/ui/search/search.js
@@ -104,9 +104,8 @@ var Search = View.extend({
 
     if (places && places.length > 0) {
       var location = places[0];
-
-      this.model.setCenter(location.center);
-      this.model.setZoom(this._getZoomByCategory(location.type));
+      var zoom = this._getZoomByCategory(location.type);
+      this.model.setView(location.center, zoom, { silent: false });
 
       if (this.options.searchPin) {
         this._createSearchPin(location.center, address);


### PR DESCRIPTION
Fixes support issue: https://github.com/CartoDB/support/issues/1888

## Acceptance:

* Open Builder.
* Import [test map](https://github.com/CartoDB/support/files/2681758/Untitled.Map.1.on.2018-12-14.at.21.18.23.zip)
* Go to edit the map
* Click the magnifying glass icon.
* Enter Atlanta GA in the search field & hit Enter.

## Expected result:

The map should be centered in Atlanta GA.
