### PR TITLE
Change Mapbox geocoder URL to the permanent one in CARTO.js v3

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
 =======
+3.15.20 (15/01/2019)
+------
+* Use geocoder permanent URL as default Mapbox URL.
+
+=======
 3.15.19 (02/01/2019)
 ------
 * Use TomTom as default geocoder.

--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,7 @@
     "cartodb.js",
     "themes/css/cartodb.css"
   ],
-  "version": "3.15.19",
+  "version": "3.15.20",
   "homepage": "https://github.com/CartoDB/cartodb.js",
   "authors": [
     "CartoDB <support@cartodb.com>"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb.js",
-  "version": "3.15.19",
+  "version": "3.15.20",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -1682,7 +1682,7 @@
         },
         "form-data": {
           "version": "0.0.3",
-          "resolved": "http://registry.npmjs.org/form-data/-/form-data-0.0.3.tgz",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-0.0.3.tgz",
           "integrity": "sha1-buoXtFeQtC13mh1YHRs2AP4MfA0=",
           "dev": true,
           "requires": {
@@ -1693,7 +1693,7 @@
           "dependencies": {
             "mime": {
               "version": "1.2.2",
-              "resolved": "http://registry.npmjs.org/mime/-/mime-1.2.2.tgz",
+              "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.2.tgz",
               "integrity": "sha1-udY1W/U+jX1WaTEw5FHa/zQBSM8=",
               "dev": true
             }
@@ -1701,7 +1701,7 @@
         },
         "mime": {
           "version": "1.2.7",
-          "resolved": "http://registry.npmjs.org/mime/-/mime-1.2.7.tgz",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.7.tgz",
           "integrity": "sha1-x6E/M6cHPZkA8ohDawazoWIAhls=",
           "dev": true
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cartodb.js",
-  "version": "3.15.19",
+  "version": "3.15.20",
   "description": "CartoDB javascript library",
   "repository": {
     "type": "git",

--- a/src/cartodb.js
+++ b/src/cartodb.js
@@ -5,7 +5,7 @@
 
     var cdb = root.cdb = {};
 
-    cdb.VERSION = "3.15.19";
+    cdb.VERSION = "3.15.20";
     cdb.DEBUG = false;
 
     cdb.CARTOCSS_VERSIONS = {

--- a/src/geo/geocoders/mapbox_geocoder.js
+++ b/src/geo/geocoders/mapbox_geocoder.js
@@ -29,7 +29,9 @@ cdb.geo.geocoder.MAPBOX = {
       protocol = 'http:';
     }
 
-    $.getJSON(protocol + '//api.mapbox.com/geocoding/v5/mapbox.places/' + encodeURIComponent(address) + '.json?access_token=' + this.keys.access_token, function (response) {
+    var requestUrl = protocol + '//api.mapbox.com/geocoding/v5/mapbox.places-permanent/' + encodeURIComponent(address) + '.json?access_token=' + this.keys.access_token;
+
+    $.getJSON(requestUrl, function (response) {
       callback(this._formatResponse(response));
     }.bind(this));
   },


### PR DESCRIPTION
This PR changes Mapbox Geocoder ephemeral URL to permanent URL in CARTO.js v3.

Related to https://github.com/CartoDB/carto.js/issues/2217