### PR TITLE
Change Mapbox API endpoint to permanent URL in CARTO.js v4

### DIFF
--- a/src/geo/geocoder/mapbox-geocoder.js
+++ b/src/geo/geocoder/mapbox-geocoder.js
@@ -1,4 +1,4 @@
-var ENDPOINT = 'https://api.mapbox.com/geocoding/v5/mapbox.places/{{address}}.json?access_token={{access_token}}';
+var ENDPOINT = 'https://api.mapbox.com/geocoding/v5/mapbox.places-permanent/{{address}}.json?access_token={{access_token}}';
 
 var TYPES = {
   country: 'country',


### PR DESCRIPTION
This PR changes URL to Mapbox permanent URL in CARTO.js v4.

Related to #2217 