### PR TITLE
Remove unused .gitmodules from repository

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "test/lib/phantom-jasmine"]
-	path = test/lib/phantom-jasmine
-	url = git://github.com/jcarver989/phantom-jasmine.git


### PR DESCRIPTION
This PR removes unused `.gitmodules` file containing `phantom-jasmine` submodule from repository.

Related to and fixes #2207 