### PR TITLE
Enable search box geocoder provider selection

### DIFF
--- a/src/api/create-vis.js
+++ b/src/api/create-vis.js
@@ -3,7 +3,6 @@ var VisView = require('../vis/vis-view');
 var VisModel = require('../vis/vis');
 var Loader = require('../core/loader');
 var VizJSON = require('./vizjson');
-var config = require('../cdb.config');
 
 var DEFAULT_OPTIONS = {
   tiles_loader: true,
@@ -56,10 +55,6 @@ var createVis = function (el, vizjson, options) {
     });
   } else {
     loadVizJSON(el, visModel, vizjson, options);
-  }
-
-  if (options.mapzenApiKey) {
-    config.set('mapzenApiKey', options.mapzenApiKey);
   }
 
   return visModel;

--- a/src/geo/ui/search/search.js
+++ b/src/geo/ui/search/search.js
@@ -15,6 +15,11 @@ var GEOCODERS = {
   'mapbox': mapboxGeocoder
 };
 
+var GEOCODERS_WINDOW_API_KEYS = {
+  'tomtom': 'tomtomApiKey',
+  'mapbox': 'mapboxApiKey'
+};
+
 /**
  *  UI component to place the map in the
  *  location found by the geocoder.
@@ -66,7 +71,9 @@ var Search = View.extend({
 
     this.geocoderService = this.options.geocoderService || injectedGeocoderConfig.provider || DEFAULT_GEOCODER;
     this.geocoder = GEOCODERS[this.geocoderService];
-    this.token = this.options.token || injectedGeocoderConfig.token;
+
+    const windowApiKey = GEOCODERS_WINDOW_API_KEYS[this.geocoderService];
+    this.token = this.options.token || injectedGeocoderConfig.token || window[windowApiKey];
   },
 
   render: function () {
@@ -213,7 +220,8 @@ var Search = View.extend({
     let token;
 
     if (provider) {
-      token = window.geocoderConfiguration[provider].search_bar_api_key;
+      token = window.geocoderConfiguration[provider] &&
+        window.geocoderConfiguration[provider].search_bar_api_key;
     }
 
     return { provider, token };

--- a/src/geo/ui/search/search.js
+++ b/src/geo/ui/search/search.js
@@ -15,11 +15,6 @@ var GEOCODERS = {
   'mapbox': mapboxGeocoder
 };
 
-var GEOCODERS_WINDOW_API_KEYS = {
-  'tomtom': 'tomtomApiKey',
-  'mapbox': 'mapboxApiKey'
-};
-
 /**
  *  UI component to place the map in the
  *  location found by the geocoder.
@@ -67,11 +62,11 @@ var Search = View.extend({
   },
 
   _initializeGeocoder: function () {
-    this.geocoderService = this.options.geocoderService || DEFAULT_GEOCODER;
-    this.geocoder = GEOCODERS[this.geocoderService];
+    const injectedGeocoderConfig = this._getGeocodingInfoFromConfig();
 
-    const windowApiKey = GEOCODERS_WINDOW_API_KEYS[this.geocoderService];
-    this.token = this.options.token || window[windowApiKey];
+    this.geocoderService = this.options.geocoderService || injectedGeocoderConfig.provider || DEFAULT_GEOCODER;
+    this.geocoder = GEOCODERS[this.geocoderService];
+    this.token = this.options.token || injectedGeocoderConfig.token;
   },
 
   render: function () {
@@ -207,6 +202,21 @@ var Search = View.extend({
   _unbindEvents: function () {
     this._searchPin && this._searchPin.unbind('click', this._toggleSearchInfowindow, this);
     this.mapView.unbind('click', this._destroySearchPin, this);
+  },
+
+  _getGeocodingInfoFromConfig () {
+    if (!window.geocoderConfiguration) {
+      return {};
+    }
+
+    const provider = window.geocoderConfiguration.provider;
+    let token;
+
+    if (provider) {
+      token = window.geocoderConfiguration[provider].search_bar_api_key;
+    }
+
+    return { provider, token };
   },
 
   clean: function () {

--- a/test/spec/geo/ui/search.spec.js
+++ b/test/spec/geo/ui/search.spec.js
@@ -194,6 +194,87 @@ describe('geo/ui/search', function () {
     });
   });
 
+  describe('_initializeGeocoder', function () {
+    it('should set geocoder from options if available', function () {
+      this.view = new Search({
+        model: this.map,
+        mapView: this.mapView,
+        geocoderService: 'mapbox',
+        token: 'token_from_options'
+      });
+
+      expect(this.view.geocoderService).toBe('mapbox');
+      expect(this.view.token).toBe('token_from_options');
+    });
+
+    it('should set geocoder from injected configuration if available', function () {
+      spyOn(Search.prototype, '_getGeocodingInfoFromConfig').and.returnValue({
+        provider: 'tomtom_fake',
+        token: 'fakeAPIKey'
+      });
+
+      this.view = new Search({
+        model: this.map,
+        mapView: this.mapView
+      });
+
+      expect(this.view.geocoderService).toBe('tomtom_fake');
+      expect(this.view.token).toBe('fakeAPIKey');
+    });
+
+    it('should set default geocoder if no configurations are available', function () {
+      Object.defineProperty(window, 'tomtomApiKey', {
+        value: 'fake_tomtom_key',
+        writable: true
+      });
+
+      this.view = new Search({
+        model: this.map,
+        mapView: this.mapView
+      });
+
+      expect(this.view.geocoderService).toBe('tomtom');
+      expect(this.view.token).toBe('fake_tomtom_key');
+    });
+  });
+
+  describe('_getGeocodingInfoFromConfig', function () {
+    it('should return an empty object if there is no geocoderConfiguration', function () {
+      expect(this.view._getGeocodingInfoFromConfig()).toEqual({});
+    });
+
+    it('should return provider and token from geocoderConfiguration', function () {
+      var geocoderConfiguration = {
+        provider: 'tomtom',
+        tomtom: {
+          search_bar_api_key: 'fakeAPIKey'
+        }
+      };
+
+      Object.defineProperty(window, 'geocoderConfiguration', {
+        value: geocoderConfiguration,
+        writable: true
+      });
+
+      expect(this.view._getGeocodingInfoFromConfig()).toEqual({
+        provider: 'tomtom', token: 'fakeAPIKey'
+      });
+    });
+
+    it('should return undefined provider and token if no provider found in geocoderConfiguration', function () {
+      var geocoderConfiguration = {};
+
+      Object.defineProperty(window, 'geocoderConfiguration', {
+        value: geocoderConfiguration,
+        writable: true
+      });
+
+      expect(this.view._getGeocodingInfoFromConfig()).toEqual({
+        provider: undefined, token: undefined
+      });
+    });
+  });
+
   afterEach(function () {
     this.$el.remove();
   });


### PR DESCRIPTION
This PR allow us to select the geocoding provider for the search box overlay in Builder by injecting `geocodingConfiguration` variable containing the needed configuration into window scope.

Mirror PR from `cartodb`: https://github.com/CartoDB/cartodb/pull/14622
Related to #2223.