### PR TITLE
Add npm install note in Overview guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Changed
+- Improve Overview guide with npm info [2230](https://github.com/CartoDB/carto.js/issues/2230)
+
 ## 4.1.11 - 2019-02-13
 ### Changed
 - Using Google Maps v3.35 on examples [2227](https://github.com/CartoDB/carto.js/pull/2227)

--- a/docs/guides/01-overview.md
+++ b/docs/guides/01-overview.md
@@ -126,6 +126,9 @@ To load the Maps JavaScript API, use a script tag like the one in the following 
 
 The URL contained in the script tag is the location of a JavaScript file that loads all of the code you need for using the CARTO.js library. This script tag is required. We are using the minified version of the library.
 
+**Tip:** if you have experience with **npm** and a build system in your project (webpack, rollup…), you can install CARTO.js library with `npm install @carto/carto.js`. Then you can import it easily with `import carto from '@carto/carto.js` (or `var carto = require('@carto/carto.js')`, depending on your module system).
+
+
 #### HTTPS or HTTP
 We think security on the web is pretty important, and recommend using HTTPS whenever possible. As part of our efforts to make the web more secure, we've made all of the CARTO components available over HTTPS. Using HTTPS encryption makes your site more secure, and more resistant to snooping or tampering.
 


### PR DESCRIPTION
Fixes #2230 

This adds a note in Overview guide regarding the name of the npm package.
It will be available when publishing the next CARTO.js version to dev-center