### PR TITLE
Change attribution character and toggle widget based on container

### DIFF
--- a/CHANGELOG_INTERNAL.md
+++ b/CHANGELOG_INTERNAL.md
@@ -4,6 +4,9 @@ This file contains all the changes in the **internal bundle** (used by Builder).
 
 All the changes that affects the public bundle should be released as *patch* or *minor* and be included in the main Changelog.
 
+## 4.1.12-0 - 2019-08-02
+- Change attribution character and toggle widget based on container [#2235](https://github.com/CartoDB/carto.js/pull/2235)
+
 ## 4.1.11-0 - 2019-01-22
 - Enable search box geocoder provider selection [#2224](https://github.com/CartoDB/carto.js/pull/2224)
 

--- a/CHANGELOG_INTERNAL.md
+++ b/CHANGELOG_INTERNAL.md
@@ -4,7 +4,7 @@ This file contains all the changes in the **internal bundle** (used by Builder).
 
 All the changes that affects the public bundle should be released as *patch* or *minor* and be included in the main Changelog.
 
-## 4.1.12-0 - 2019-08-02
+## 4.1.11-1 - 2019-08-02
 - Change attribution character and toggle widget based on container [#2235](https://github.com/CartoDB/carto.js/pull/2235)
 
 ## 4.1.11-0 - 2019-01-22

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "Jesus Arroyo Torrens <jarroyo@carto.com>",
     "Iago Lastra <iago@carto.com>",
     "Elena Torró <elena@carto.com>",
-    "Jesús Botella <jbotella@carto.com>"
+    "Jesús Botella <jbotella@carto.com>",
+    "Alejandra Arri <alejandraarri@carto.com>"
   ],
   "private": true,
   "license": "BSD-3-Clause",

--- a/src/geo/ui/attribution/attribution-template.tpl
+++ b/src/geo/ui/attribution/attribution-template.tpl
@@ -1,4 +1,4 @@
 <div class="CDB-Overlay">
-  <button type="button" class="CDB-Attribution-button js-button">?</button>
+  <button type="button" class="CDB-Attribution-button js-button">©</button>
   <p class="CDB-Attribution-text js-text u-ellipsis"><%= attributions %></p>
 </div>

--- a/src/geo/ui/attribution/attribution-view.js
+++ b/src/geo/ui/attribution/attribution-view.js
@@ -26,6 +26,7 @@ module.exports = View.extend({
 
     this._onDocumentClick = this._onDocumentClick.bind(this);
     this._onDocumentKeyDown = this._onDocumentKeyDown.bind(this);
+    this._toggleAttributionsBasedOnContainer = this._toggleAttributionsBasedOnContainer.bind(this);
 
     this._initBinds();
   },
@@ -39,6 +40,8 @@ module.exports = View.extend({
       })
     );
     this.$el.toggleClass('CDB-Attribution--gmaps', !!isGMaps);
+    this._toggleAttributionsBasedOnContainer();
+
     return this;
   },
 
@@ -48,6 +51,7 @@ module.exports = View.extend({
     }, this);
     this.map.bind('change:attribution', this.render, this);
     this.add_related_model(this.map);
+    $(window).bind('resize', this._toggleAttributionsBasedOnContainer);
   },
 
   _enableDocumentBinds: function () {
@@ -80,6 +84,15 @@ module.exports = View.extend({
     this.model.set('visible', !this.model.get('visible'));
   },
 
+  _toggleAttributionsBasedOnContainer: function () {
+    var MAP_CONTAINER_MOBILE_WIDTH = 650;
+    if (this.map.getMapViewSize().x > MAP_CONTAINER_MOBILE_WIDTH) {
+      this._showAttributions();
+    } else {
+      this._hideAttributions();
+    }
+  },
+
   _onDocumentClick: function (ev) {
     if (!$(ev.target).closest(this.el).length) {
       this._toggleAttributions();
@@ -88,6 +101,7 @@ module.exports = View.extend({
 
   clean: function () {
     this._disableDocumentBinds();
+    $(window).unbind('resize', this._toggleAttributionsBasedOnContainer);
     View.prototype.clean.call(this);
   }
 });

--- a/test/spec/geo/ui/attribution-view.spec.js
+++ b/test/spec/geo/ui/attribution-view.spec.js
@@ -17,6 +17,7 @@ describe('geo/ui/attribution', function () {
     this.map = new Map(null, {
       layersFactory: {}
     });
+    this.map.setMapViewSize({ x: 650, y: 1000 });
     spyOn(this.map, 'bind').and.callThrough();
     spyOn(AttributionView.prototype, 'render').and.callThrough();
 
@@ -35,6 +36,20 @@ describe('geo/ui/attribution', function () {
     it('should render properly', function () {
       expect(this.$button.length).toBe(1);
       expect(this.$text.length).toBe(1);
+    });
+
+    it('should render expanded if map container is greater than 650px', function () {
+      this.map.setMapViewSize({ x: 750, y: 1000 });
+      this.view.render();
+      expect(this.viewHasClass('CDB-Attribution')).toBeTruthy();
+      expect(this.viewHasClass('is-active')).toBeTruthy();
+    });
+
+    it('should render collapsed if map container is smaller than 650px', function () {
+      this.map.setMapViewSize({ x: 450, y: 1000 });
+      this.view.render();
+      expect(this.viewHasClass('CDB-Attribution')).toBeTruthy();
+      expect(this.viewHasClass('is-active')).toBeFalsy();
     });
 
     it('should add GMaps properly when provider is not Leaflet', function () {

--- a/test/spec/vis/overlays-factory.spec.js
+++ b/test/spec/vis/overlays-factory.spec.js
@@ -6,6 +6,9 @@ describe('vis/overlays-factory', function () {
   beforeEach(function () {
     this.map = new Backbone.Model();
     this.map.layers = new Backbone.Collection();
+    this.map.getMapViewSize = function () {
+      return { x: 650, y: 1000 };
+    };
 
     this.mapView = new Backbone.View();
     this.mapView.map = this.map;

--- a/test/spec/vis/vis-view.spec.js
+++ b/test/spec/vis/vis-view.spec.js
@@ -53,6 +53,7 @@ describe('vis/vis-view', function () {
     this.visView = createVisView(this.container, this.visModel, this.settingsModel);
 
     this.visModel.load(new VizJSON(this.mapConfig));
+    this.visModel.map.setMapViewSize({ x: 650, y: 1000 });
     this.visView.render();
   });
 


### PR DESCRIPTION
This PR is to change the attribution widget character because it can be confusing as suggested in 
https://github.com/CartoDB/cartodb/issues/14914.

We are also making the widget to appear condensed when the map width is small enough to prevent if from taking too much space, and appear expanded in bigger map sizes so the attributions appear clearly visible.