### PR TITLE
Fix attribution widget

### DIFF
--- a/CHANGELOG_INTERNAL.md
+++ b/CHANGELOG_INTERNAL.md
@@ -4,6 +4,9 @@ This file contains all the changes in the **internal bundle** (used by Builder).
 
 All the changes that affects the public bundle should be released as *patch* or *minor* and be included in the main Changelog.
 
+## 4.1.12-1 - 2019-08-06
+- Attributions widget: prevent autocollapsing and fix button bug [#2236](https://github.com/CartoDB/carto.js/pull/2236)
+
 ## 4.1.12-0 - 2019-08-02
 - Change attribution character and toggle widget based on container [#2235](https://github.com/CartoDB/carto.js/pull/2235)
 

--- a/src/geo/ui/attribution/attribution-view.js
+++ b/src/geo/ui/attribution/attribution-view.js
@@ -87,9 +87,9 @@ module.exports = View.extend({
   _toggleAttributionsBasedOnContainer: function () {
     var MAP_CONTAINER_MOBILE_WIDTH = 650;
     if (this.map.getMapViewSize().x > MAP_CONTAINER_MOBILE_WIDTH) {
-      this._showAttributions();
+      this.model.set('visible', true);
     } else {
-      this._hideAttributions();
+      this.model.set('visible', false);
     }
   },
 

--- a/src/geo/ui/attribution/attribution-view.js
+++ b/src/geo/ui/attribution/attribution-view.js
@@ -24,7 +24,6 @@ module.exports = View.extend({
     });
     this.map = this.options.map;
 
-    this._onDocumentClick = this._onDocumentClick.bind(this);
     this._onDocumentKeyDown = this._onDocumentKeyDown.bind(this);
     this._toggleAttributionsBasedOnContainer = this._toggleAttributionsBasedOnContainer.bind(this);
 
@@ -56,12 +55,10 @@ module.exports = View.extend({
 
   _enableDocumentBinds: function () {
     $(document).bind('keydown', this._onDocumentKeyDown);
-    $(document).bind('click', this._onDocumentClick);
   },
 
   _disableDocumentBinds: function () {
     $(document).unbind('keydown', this._onDocumentKeyDown);
-    $(document).unbind('click', this._onDocumentClick);
   },
 
   _onDocumentKeyDown: function (ev) {
@@ -90,12 +87,6 @@ module.exports = View.extend({
       this.model.set('visible', true);
     } else {
       this.model.set('visible', false);
-    }
-  },
-
-  _onDocumentClick: function (ev) {
-    if (!$(ev.target).closest(this.el).length) {
-      this._toggleAttributions();
     }
   },
 

--- a/test/spec/geo/ui/attribution-view.spec.js
+++ b/test/spec/geo/ui/attribution-view.spec.js
@@ -91,11 +91,6 @@ describe('geo/ui/attribution', function () {
       this.keyEsc();
       expect(this.viewHasClass('is-active')).toBeFalsy();
     });
-
-    it('should collapse the attributions when user clicks on the document', function () {
-      $(document).trigger('click');
-      expect(this.viewHasClass('is-active')).toBeFalsy();
-    });
   });
 
   describe('when attributions are hidden', function () {


### PR DESCRIPTION
This PR is related to https://github.com/CartoDB/carto.js/pull/2235. 
This PR only contains a fix for a mini bug that made the attributions button not work the first time it was pressed. This is because changes in the view should be done by changing the model so view and and model don't desynchronize.

Also, prevent autocollapsing the attributions widget when user clicks on the document.