### PR TITLE
Fix scroll in gradient legends

### DIFF
--- a/themes/scss/map/_overlays.scss
+++ b/themes/scss/map/_overlays.scss
@@ -293,6 +293,11 @@ $maxLegendContainerHeight: 300px;
   z-index: 3;
 }
 
+.Legends {
+  display: flex;
+  flex-direction: column;
+}
+
 .CDB-Legend-item {
   height: 100%;
 }


### PR DESCRIPTION
https://github.com/CartoDB/support/issues/1521

Using `flex` in `Legends` element to include margin in gradient legend.
(Margin was added to cover average text below the bar)