### PR TITLE
Return a new instance of source filters array

### DIFF
--- a/src/api/v4/filter/filters-collection.js
+++ b/src/api/v4/filter/filters-collection.js
@@ -88,7 +88,7 @@ class FiltersCollection extends Base {
    * @api
    */
   getFilters () {
-    return this._filters;
+    return [].concat(this._filters);
   }
 
   $getSQL () {


### PR DESCRIPTION
This PR modifies `getFilters()` method return value, given that there might be some incorrect behaviours when reusing that original array.

@oriolbx has found a bug that when trying to remove filters from the source with `source.getFilters()` didn't work properly because we were modifying the same array.