### PR TITLE
Update basemaps attribution to match requirements from the data provider

### DIFF
--- a/src/api/v4/constants.js
+++ b/src/api/v4/constants.js
@@ -87,14 +87,14 @@ function isValidTimeAggregation (agg) {
 /**
  * ATTRIBUTION constant
  *
- * &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>
+ * &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://www.maptiler.com/copyright/">MapTiler</a>, &copy; <a href="https://carto.com/attribution">CARTO</a>
  *
  * @type {string}
  * @constant
  * @memberof carto
  * @api
  */
-var ATTRIBUTION = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>';
+var ATTRIBUTION = '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://www.maptiler.com/copyright/">MapTiler</a>, &copy; <a href="https://carto.com/attribution">CARTO</a>';
 
 module.exports = {
   operation: operation,

--- a/test/spec/api/v4/client.spec.js
+++ b/test/spec/api/v4/client.spec.js
@@ -356,9 +356,9 @@ describe('api/v4/client', function () {
       expect(leafletLayer instanceof L.TileLayer).toBe(true);
     });
 
-    it('should have the OpenStreetMap / Carto attribution', function () {
+    it('should have the OpenStreetMap, MapTiler and CARTO attribution', function () {
       expect(leafletLayer.getAttribution()).toBe(
-        '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://carto.com/attribution">CARTO</a>'
+        '&copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors, &copy; <a href="https://www.maptiler.com/copyright/">MapTiler</a>, &copy; <a href="https://carto.com/attribution">CARTO</a>'
       );
     });
 


### PR DESCRIPTION
We need to update our basemaps attribution line. I think this is the place to change it in `carto.js` :)