### PR TITLE
add 5 retries for s3 upload tasks

### DIFF
--- a/grunt/tasks/s3.js
+++ b/grunt/tasks/s3.js
@@ -12,7 +12,8 @@ module.exports = {
         accessKeyId: "<%= secrets.AWS_USER_S3_KEY %>",
         secretAccessKey: "<%= secrets.AWS_USER_S3_SECRET %>",
         bucket: "<%= secrets.AWS_S3_BUCKET %>",
-        dryRun: false
+        dryRun: false,
+	maxRetries: 5
       }
     };
 


### PR DESCRIPTION
- Related to: https://github.com/CartoDB/cartodb-platform/issues/6643
- We need to set this `maxRetries` option to retry the s3 upload tasks that are usually failing during the build assets tasks in deploys.