### PR TITLE
Replace reference to carto.com/attributions by carto.com/about-carto/

### DIFF
--- a/src/cdb.config.js
+++ b/src/cdb.config.js
@@ -2,7 +2,7 @@ var Config = require('./core/config');
 
 var config = new Config();
 config.set({
-  cartodb_attributions: '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>',
+  cartodb_attributions: '© <a href="https://carto.com/about-carto/" target="_blank">CARTO</a>',
   cartodb_logo_link: 'http://www.carto.com'
 });
 

--- a/test/spec/api/vizjson.spec.js
+++ b/test/spec/api/vizjson.spec.js
@@ -212,7 +212,7 @@ describe('src/vis/vizjson', function () {
             url: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
             name: 'Positron',
             className: 'httpsbasemapscartocdncomlight_nolabelszxypng',
-            attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'https://carto.com/attributions\'>CARTO</a>',
+            attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'https://carto.com/about-carto/\'>CARTO</a>',
             urlTemplate: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'
           }
         }]
@@ -244,7 +244,7 @@ describe('src/vis/vizjson', function () {
             url: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
             name: 'Positron',
             className: 'httpsbasemapscartocdncomlight_nolabelszxypng',
-            attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'https://carto.com/attributions\'>CARTO</a>',
+            attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'https://carto.com/about-carto/\'>CARTO</a>',
             urlTemplate: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'
           }
         }]
@@ -258,7 +258,7 @@ describe('src/vis/vizjson', function () {
           url: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
           name: 'Positron',
           className: 'httpsbasemapscartocdncomlight_nolabelszxypng',
-          attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'https://carto.com/attributions\'>CARTO</a>',
+          attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'https://carto.com/about-carto/\'>CARTO</a>',
           urlTemplate: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'
         }
       });
@@ -275,7 +275,7 @@ describe('src/vis/vizjson', function () {
             url: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
             name: 'Positron',
             className: 'httpsbasemapscartocdncomlight_nolabelszxypng',
-            attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'https://carto.com/attributions\'>CARTO</a>',
+            attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'https://carto.com/about-carto/\'>CARTO</a>',
             urlTemplate: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'
           }
         }]
@@ -289,7 +289,7 @@ describe('src/vis/vizjson', function () {
           url: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png',
           name: 'Positron',
           className: 'httpsbasemapscartocdncomlight_nolabelszxypng',
-          attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'https://carto.com/attributions\'>CARTO</a>',
+          attribution: '&copy; <a href=\'http://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors &copy; <a href= \'https://carto.com/about-carto/\'>CARTO</a>',
           urlTemplate: 'http://{s}.basemaps.cartocdn.com/light_nolabels/{z}/{x}/{y}.png'
         }
       });

--- a/test/spec/cartodb.spec.js
+++ b/test/spec/cartodb.spec.js
@@ -72,7 +72,7 @@ describe('cartodb.js bundle', function () {
     });
 
     it('config should contain links variables', function () {
-      expect(cdb.config.get('cartodb_attributions')).toEqual('© <a href="https://carto.com/attributions" target="_blank">CARTO</a>');
+      expect(cdb.config.get('cartodb_attributions')).toEqual('© <a href="https://carto.com/about-carto/" target="_blank">CARTO</a>');
       expect(cdb.config.get('cartodb_logo_link')).toEqual('http://www.carto.com');
     });
 

--- a/test/spec/geo/map.spec.js
+++ b/test/spec/geo/map.spec.js
@@ -190,7 +190,7 @@ describe('core/geo/map', function () {
 
     // Map has the default CartoDB attribution
     expect(map.get('attribution')).toEqual([
-      '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
+      '© <a href="https://carto.com/about-carto/" target="_blank">CARTO</a>'
     ]);
 
     var layer1 = new CartoDBLayer({ attribution: 'attribution1' }, { engine: engineMock });
@@ -204,7 +204,7 @@ describe('core/geo/map', function () {
     expect(map.get('attribution')).toEqual([
       'attribution1',
       'wadus',
-      '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
+      '© <a href="https://carto.com/about-carto/" target="_blank">CARTO</a>'
     ]);
 
     var layer = new CartoDBLayer({ attribution: 'attribution2' }, { engine: engineMock });
@@ -216,7 +216,7 @@ describe('core/geo/map', function () {
       'attribution1',
       'wadus',
       'attribution2',
-      '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
+      '© <a href="https://carto.com/about-carto/" target="_blank">CARTO</a>'
     ]);
 
     layer.set('attribution', 'new attribution');
@@ -226,7 +226,7 @@ describe('core/geo/map', function () {
       'attribution1',
       'wadus',
       'new attribution',
-      '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
+      '© <a href="https://carto.com/about-carto/" target="_blank">CARTO</a>'
     ]);
 
     map.layers.remove(layer);
@@ -234,7 +234,7 @@ describe('core/geo/map', function () {
     expect(map.get('attribution')).toEqual([
       'attribution1',
       'wadus',
-      '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
+      '© <a href="https://carto.com/about-carto/" target="_blank">CARTO</a>'
     ]);
 
     // Addind a layer with the default attribution
@@ -246,7 +246,7 @@ describe('core/geo/map', function () {
     expect(map.get('attribution')).toEqual([
       'attribution1',
       'wadus',
-      '© <a href="https://carto.com/attributions" target="_blank">CARTO</a>'
+      '© <a href="https://carto.com/about-carto/" target="_blank">CARTO</a>'
     ]);
   });
 

--- a/test/spec/vis/vis.spec.js
+++ b/test/spec/vis/vis.spec.js
@@ -40,7 +40,7 @@ var fakeVizJSON = function () {
           'maxZoom': '18',
           'name': 'Positron',
           'className': 'positron_rainbow_labels',
-          'attribution': '&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors &copy; <a href=\"https://carto.com/attributions\">CARTO</a>',
+          'attribution': '&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors &copy; <a href=\"https://carto.com/about-carto/\">CARTO</a>',
           'labels': {
             'url': 'http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png'
           },
@@ -105,7 +105,7 @@ var fakeVizJSON = function () {
           'subdomains': 'abcd',
           'minZoom': '0',
           'maxZoom': '18',
-          'attribution': '&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors &copy; <a href=\"https://carto.com/attributions\">CARTO</a>',
+          'attribution': '&copy; <a href=\"http://www.openstreetmap.org/copyright\">OpenStreetMap</a> contributors &copy; <a href=\"https://carto.com/about-carto/\">CARTO</a>',
           'urlTemplate': 'http://{s}.basemaps.cartocdn.com/light_only_labels/{z}/{x}/{y}.png',
           'type': 'Tiled',
           'name': 'Positron Labels'


### PR DESCRIPTION
The new attributions page is https://carto.com/about-carto/