### PR TITLE
Replace git:// with https:// in package.json files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6465,8 +6465,8 @@
       }
     },
     "grunt-contrib-watch": {
-      "version": "git://github.com/gruntjs/grunt-contrib-watch.git#b884948805940c663b1cbb91a3c28ba8afdebf78",
-      "from": "git://github.com/gruntjs/grunt-contrib-watch.git#b884948805940c663b1cbb91a3c28ba8afdebf78",
+      "version": "https://github.com/gruntjs/grunt-contrib-watch.git#b884948805940c663b1cbb91a3c28ba8afdebf78",
+      "from": "https://github.com/gruntjs/grunt-contrib-watch.git#b884948805940c663b1cbb91a3c28ba8afdebf78",
       "dev": true,
       "requires": {
         "async": "~0.2.9",
@@ -8938,8 +8938,8 @@
       "dev": true
     },
     "jasmine-ajax": {
-      "version": "git://github.com/nobuti/jasmine-ajax.git#7b1047a4b6c8e8c0e7dc5419059ed6f2c3fc00f4",
-      "from": "git://github.com/nobuti/jasmine-ajax.git#master",
+      "version": "https://github.com/nobuti/jasmine-ajax.git#7b1047a4b6c8e8c0e7dc5419059ed6f2c3fc00f4",
+      "from": "https://github.com/nobuti/jasmine-ajax.git#master",
       "dev": true
     },
     "jasmine-core": {
@@ -11273,8 +11273,8 @@
       "dev": true
     },
     "perfect-scrollbar": {
-      "version": "git://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
-      "from": "git://github.com/CartoDB/perfect-scrollbar.git#master"
+      "version": "https://github.com/CartoDB/perfect-scrollbar.git#f2b66c76ad3718d3c704bd7e1693ea382e44e64d",
+      "from": "https://github.com/CartoDB/perfect-scrollbar.git#master"
     },
     "performance-now": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CARTO javascript library",
   "repository": {
     "type": "git",
-    "url": "git://github.com/CartoDB/carto.js.git"
+    "url": "https://github.com/CartoDB/carto.js.git"
   },
   "author": {
     "name": "CARTO",
@@ -44,7 +44,7 @@
     "d3-time-format": "2.1.0",
     "jquery": "2.1.4",
     "mustache": "1.1.0",
-    "perfect-scrollbar": "git://github.com/CartoDB/perfect-scrollbar.git#master",
+    "perfect-scrollbar": "https://github.com/CartoDB/perfect-scrollbar.git#master",
     "postcss": "5.0.19",
     "promise-polyfill": "^6.1.0",
     "torque.js": "CartoDB/torque#master",
@@ -80,7 +80,7 @@
     "grunt-contrib-cssmin": "~0.7.0",
     "grunt-contrib-imagemin": "~1.0.0",
     "grunt-contrib-jasmine": "1.1.0",
-    "grunt-contrib-watch": "git://github.com/gruntjs/grunt-contrib-watch.git#b884948805940c663b1cbb91a3c28ba8afdebf78",
+    "grunt-contrib-watch": "https://github.com/gruntjs/grunt-contrib-watch.git#b884948805940c663b1cbb91a3c28ba8afdebf78",
     "grunt-eslint": "~20.1.0",
     "grunt-exorcise": "2.1.0",
     "grunt-fastly": "~0.1.3",
@@ -94,7 +94,7 @@
     "gulp-iconfont-css": "0.0.9",
     "gulp-install": "0.2.0",
     "gulp-sketch": "0.0.7",
-    "jasmine-ajax": "git://github.com/nobuti/jasmine-ajax.git#master",
+    "jasmine-ajax": "https://github.com/nobuti/jasmine-ajax.git#master",
     "jsdoc": "~3.5.5",
     "jstify": "0.12.0",
     "leaflet": "1.3.1",


### PR DESCRIPTION
Github is removing git:// access because it's insecure.
https://github.blog/2021-09-01-improving-git-protocol-security-github/