### PR TITLE
Updating v3 github URL to https

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "CartoDB javascript library",
   "repository": {
     "type": "git",
-    "url": "git://github.com/CartoDB/cartodb.js.git"
+    "url": "https://github.com/CartoDB/cartodb.js.git"
   },
   "author": {
     "name": "CARTO",


### PR DESCRIPTION
Shortcut: https://app.shortcut.com/cartoteam/story/221282/carto2-deploys-are-broken-due-to-git-protocol-security-enforment
Github security notice: https://github.blog/2021-09-01-improving-git-protocol-security-github/
cartodb-platform: https://github.com/CartoDB/cartodb-platform/pull/7245/files
cartodb: https://github.com/CartoDB/cartodb/pull/16407
Deploy to staging cloud: http://deploy.int.cartodb.net/job/Carto_deploy_to_staging_(carto.com)_stag/3019/console

## **Changes**:
- Update github URLs from `git://github.com/CartoDB` to `git@github.com:CartoDB`
- Update `package.json` git URLs from `git://github.com/CartoDB` to `github:CartoDB || https://`